### PR TITLE
Panos: First version of the merged drafts.

### DIFF
--- a/draft-vanderstok-ace-coap-est-01.html
+++ b/draft-vanderstok-ace-coap-est-01.html
@@ -1,0 +1,1378 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://dublincore.org/documents/2008/08/04/dc-html/">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index,nofollow" />
+    <meta name="creator" content="rfcmarkup version 1.96" />
+    <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
+
+    <link rel="icon" href="" type="image/png" />
+    <link rel="shortcut icon" href="" type="image/png" />
+    <title>draft-vanderstok-ace-coap-est-01.txt - EST over secure CoAP (EST-coaps)</title>
+    
+    
+    <style type="text/css">
+	body {
+	    margin: 0px 8px;
+            font-size: 1em;
+	}
+        h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+	    font-weight: bold;
+            line-height: 0pt;
+            display: inline;
+            white-space: pre;
+            font-family: monospace;
+            font-size: 1em;
+	    font-weight: bold;
+        }
+        pre {
+            font-size: 1em;
+            margin-top: 0px;
+            margin-bottom: 0px;
+        }
+	.pre {
+	    white-space: pre;
+	    font-family: monospace;
+	}
+	.header{
+	    font-weight: bold;
+	}
+        .newpage {
+            page-break-before: always;
+        }
+        .invisible {
+            text-decoration: none;
+            color: white;
+        }
+        @media print {
+            body {
+                font-size: 10.5pt;
+            }
+            h1, h2, h3, h4, h5, h6 {
+                font-size: 10.5pt;
+            }
+        
+            a:link, a:visited {
+                color: inherit;
+                text-decoration: none;
+            }
+            .noprint {
+                display: none;
+            }
+        }
+	@media screen {
+	    .grey, .grey a:link, .grey a:visited {
+		color: #777;
+	    }
+            .docinfo {
+                background-color: #EEE;
+            }
+            .top {
+                border-top: 7px solid #EEE;
+            }
+            .bgwhite  { background-color: white; }
+            .bgred    { background-color: #F44; }
+            .bggrey   { background-color: #666; }
+            .bgbrown  { background-color: #840; }            
+            .bgorange { background-color: #FA0; }
+            .bgyellow { background-color: #EE0; }
+            .bgmagenta{ background-color: #F4F; }
+            .bgblue   { background-color: #66F; }
+            .bgcyan   { background-color: #4DD; }
+            .bggreen  { background-color: #4F4; }
+
+            .legend   { font-size: 90%; }
+            .cplate   { font-size: 70%; border: solid grey 1px; }
+	}
+    </style>
+    <!--[if IE]>
+    <style>
+    body {
+       font-size: 13px;
+       margin: 10px 10px;
+    }
+    </style>
+    <![endif]-->
+
+    <script type="text/javascript"><!--
+    function addHeaderTags() {
+	var spans = document.getElementsByTagName("span");
+	for (var i=0; i < spans.length; i++) {
+	    var elem = spans[i];
+	    if (elem) {
+		var level = elem.getAttribute("class");
+                if (level == "h1" || level == "h2" || level == "h3" || level == "h4" || level == "h5" || level == "h6") {
+                    elem.innerHTML = "<"+level+">"+elem.innerHTML+"</"+level+">";		
+                }
+	    }
+	}
+    }
+    var legend_html = "Colour legend:<br />      <table>         <tr><td>Unknown:</td>          <td><span class='cplate bgwhite'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Draft:</td>            <td><span class='cplate bgred'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Informational:</td>    <td><span class='cplate bgorange'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Experimental:</td>     <td><span class='cplate bgyellow'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Best Common Practice:</td><td><span class='cplate bgmagenta'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Proposed Standard:</td><td><span class='cplate bgblue'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Draft Standard:</td>   <td><span class='cplate bgcyan'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Standard:</td>         <td><span class='cplate bggreen'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Historic:</td>         <td><span class='cplate bggrey'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Obsolete:</td>         <td><span class='cplate bgbrown'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>     </table>";
+    function showElem(id) {
+        var elem = document.getElementById(id);
+        elem.innerHTML = eval(id+"_html");
+        elem.style.visibility='visible';
+    }
+    function hideElem(id) {
+        var elem = document.getElementById(id);
+        elem.style.visibility='hidden';        
+        elem.innerHTML = "";
+    }
+    // -->
+    </script>
+</head>
+<body onload="addHeaderTags()">
+   <div style="height: 13px;">
+      <div onmouseover="this.style.cursor='pointer';"
+         onclick="showElem('legend');"
+         onmouseout="hideElem('legend')"
+	 style="height: 6px; position: absolute;"
+         class="pre noprint docinfo "
+         title="Click for colour legend." >                                                                        </div>
+      <div id="legend"
+           class="docinfo noprint pre legend"
+           style="position:absolute; top: 4px; left: 4ex; visibility:hidden; background-color: white; padding: 4px 9px 5px 7px; border: solid #345 1px; "
+           onmouseover="showElem('legend');"
+           onmouseout="hideElem('legend');">
+      </div>
+   </div>
+
+<span class="pre noprint docinfo">                                                                        </span><br />
+<span class="pre noprint docinfo">                                                                        </span><br />
+<span class="pre noprint docinfo">                                                                        </span><br />
+<pre>
+ACE                                                             S. Kumar
+Internet-Draft                                 Philips Lighting Research
+Intended status: Standards Track                         P. van der Stok
+Expires: July 22, 2017                                        Consultant
+                                                           P. Kampanakis
+                                                           Cisco Systems
+                                                        January 18, 2017
+
+
+                    <span class="h1">EST over secure CoAP (EST-coaps)</span>
+                    <span class="h1">draft-vanderstok-ace-coap-est-00</span>
+
+Abstract
+
+   Low-resource devices in a Low-power and Lossy Network (LLN) can
+   operate in a mesh network using the IPv6 over Low-power Personal Area
+   Networks (6LoWPAN) and IEEE 802.15.4 link-layer standards.
+   Provisioning these devices in a secure manner with keys (often called
+   security bootstrapping) used to encrypt and authenticate messages is
+   the subject of Bootstrapping of Remote Secure Key Infrastructures
+   (BRSKI) [<a href="#ref-I-D.ietf-anima-bootstrapping-keyinfra">I-D.ietf-anima-bootstrapping-keyinfra</a>].  Enrollment over
+   Secure Transport (EST) [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>], based on TLS and HTTP, is used in
+   BRSKI.  Low-resource devices often use the lightweight Constrained
+   Application Protocol (COAP) [<a href="./rfcmarkup.sh?rfc=7252" title='"The Constrained Application Protocol (CoAP)"'>RFC7252</a>] for message exchanges.  This
+   document defines how low-resource devices are expected to use EST
+   over secure CoAP (EST-coaps) for secure bootstrapping and certificate
+   enrollment. 6LoWPAN fragmentation management and minor extensions to
+   CoAP are needed to enable EST-coaps.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of <a href="./rfcmarkup.sh?bcp=78">BCP 78</a> and <a href="./rfcmarkup.sh?bcp=79">BCP 79</a>.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at <a href="http://datatracker.ietf.org/drafts/current/">http://datatracker.ietf.org/drafts/current/</a>.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on July 22, 2017.
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 1]</span>
+</pre><pre class='newpage'><a name="page-2" id="page-2" href="#page-2" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+Copyright Notice
+
+   Copyright (c) 2017 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to <a href="./rfcmarkup.sh?bcp=78">BCP 78</a> and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (<a href="http://trustee.ietf.org/license-info">http://trustee.ietf.org/license-info</a>) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in <a href="#section-4">Section 4</a>.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   <a href="#section-1">1</a>.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-3">3</a>
+   <a href="#section-2">2</a>.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-4">4</a>
+   <a href="#section-3">3</a>.  EST/BRSKI operational differences . . . . . . . . . . . . . .   <a href="#page-4">4</a>
+   <a href="#section-4">4</a>.  Protocol Design and Layering  . . . . . . . . . . . . . . . .   <a href="#page-4">4</a>
+     <a href="#section-4.1">4.1</a>.  Message Bindings  . . . . . . . . . . . . . . . . . . . .   <a href="#page-6">6</a>
+     <a href="#section-4.2">4.2</a>.  CoAP response codes . . . . . . . . . . . . . . . . . . .   <a href="#page-7">7</a>
+     <a href="#section-4.3">4.3</a>.  Message fragmentation . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-5">5</a>.  Transport Protocol  . . . . . . . . . . . . . . . . . . . . .   <a href="#page-9">9</a>
+     <a href="#section-5.1">5.1</a>.  DTLS  . . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-10">10</a>
+     <a href="#section-5.2">5.2</a>.  [EDNOTE: Placeholder] . . . . . . . . . . . . . . . . . .  <a href="#page-11">11</a>
+   <a href="#section-6">6</a>.  Proxying  . . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-11">11</a>
+   <a href="#section-7">7</a>.  Parameters  . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-11">11</a>
+   <a href="#section-8">8</a>.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  <a href="#page-11">11</a>
+   <a href="#section-9">9</a>.  Security Considerations . . . . . . . . . . . . . . . . . . .  <a href="#page-14">14</a>
+   <a href="#section-10">10</a>. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-14">14</a>
+   <a href="#section-11">11</a>. Change Log  . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-14">14</a>
+   <a href="#section-12">12</a>. References  . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-14">14</a>
+     <a href="#section-12.1">12.1</a>.  Normative References . . . . . . . . . . . . . . . . . .  <a href="#page-14">14</a>
+     <a href="#section-12.2">12.2</a>.  Informative References . . . . . . . . . . . . . . . . .  <a href="#page-15">15</a>
+   <a href="#appendix-A">Appendix A</a>.  EST messages to EST-coaps  . . . . . . . . . . . . .  <a href="#page-16">16</a>
+     <a href="#appendix-A.1">A.1</a>.  cacerts . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-16">16</a>
+     <a href="#appendix-A.2">A.2</a>.  enroll / reenroll . . . . . . . . . . . . . . . . . . . .  <a href="#page-18">18</a>
+     <a href="#appendix-A.3">A.3</a>.  csrattr . . . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-18">18</a>
+     <a href="#appendix-A.4">A.4</a>.  enrollstatus  . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-18">18</a>
+     <a href="#appendix-A.5">A.5</a>.  voucher_status  . . . . . . . . . . . . . . . . . . . . .  <a href="#page-19">19</a>
+     <a href="#appendix-A.6">A.6</a>.  requestvoucher  . . . . . . . . . . . . . . . . . . . . .  <a href="#page-19">19</a>
+     <a href="#appendix-A.7">A.7</a>.  requestlog  . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-19">19</a>
+   <a href="#appendix-B">Appendix B</a>.  EST-coaps Block message examples . . . . . . . . . .  <a href="#page-19">19</a>
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  <a href="#page-22">22</a>
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 2]</span>
+</pre><pre class='newpage'><a name="page-3" id="page-3" href="#page-3" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+<span class="h2"><a name="section-1">1</a>.  Introduction</span>
+
+   IPv6 over Low-power Wireless Personal Area Networks (6LoWPANs)
+   [<a href="./rfcmarkup.sh?rfc=4944" title='"Transmission of IPv6 Packets over IEEE 802.15.4 Networks"'>RFC4944</a>] on IEEE 802.15.4 [<a href="#ref-ieee802.15.4">ieee802.15.4</a>] wireless networks is
+   becoming common in many industry application domains such as lighting
+   controls.  However commissioning of such networks suffers from a lack
+   of standardized secure bootstrapping mechanisms for these networks.
+
+   Although IEEE 802.15.4 defines how security can be enabled between
+   nodes within a single mesh network, it does not specify the
+   provisioning and management of the keys.  Therefore securing a
+   6LoWPAN network with devices from multiple manufacturers with
+   different provisioning techniques is often tedious and time
+   consuming.
+
+   Bootstrapping of Remote Secure Infrastructures (BRSKI)
+   [<a href="#ref-I-D.ietf-anima-bootstrapping-keyinfra">I-D.ietf-anima-bootstrapping-keyinfra</a>] addresses the issue of
+   bootstrapping networked devices in the context of Autonomic
+   Networking Integrated Model and Approach (ANIMA).  However, BRSKI has
+   not been developed specifically for low-resource devices in
+   constrained networks.  These networks use DTLS [<a href="./rfcmarkup.sh?rfc=6347" title='"Datagram Transport Layer Security Version 1.2"'>RFC6347</a>], CoAP
+   [<a href="./rfcmarkup.sh?rfc=7252" title='"The Constrained Application Protocol (CoAP)"'>RFC7252</a>], and UDP instead of TLS [<a href="./rfcmarkup.sh?rfc=5246" title='"The Transport Layer Security (TLS) Protocol Version 1.2"'>RFC5246</a>], HTTP [<a href="./rfcmarkup.sh?rfc=7230" title='"Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing"'>RFC7230</a>] and TCP.
+   BRSKI relies on HTTP RESTful APIs and enrollment over Secure
+   Transport (EST) [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>] for the provisioning of the operational
+   domain certificates.  Replacing the EST invocations of TLS and HTTP
+   by UDP and CoAP invocations enables applying BRSKI on CoAP-based low-
+   resource devices.
+
+   Although EST-coaps paves the way for the utilization of BRSKI and EST
+   for constrained devices on constrained networks, some devices will
+   not have enough resources to handle the large payloads that come with
+   EST-coaps.  The definition of EST-coaps is intended to ensure that
+   bootstrapping works for less constrained devices that choose to limit
+   their communications stack to UDP/CoAP.  It is up to the network
+   designer to decide which devices execute the EST protocol and which
+   not.
+
+   EST-coaps is designed for use in professional control networks such
+   as lighting.  The autonomic bootstrapping is interesting because it
+   reduces the manual intervention during the commissioning of the
+   network.  Typing in passwords is contrary to this wish.  Therefore,
+   the HTTP Basic authentication of EST is not supported in EST-coaps.
+
+   In the constrained devices context it is very unlikely that full PKI
+   request messages will be used.  For that reason, full PKI messages
+   are not supported in EST-coaps.
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 3]</span>
+</pre><pre class='newpage'><a name="page-4" id="page-4" href="#page-4" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   Because the relatively large messages involved in EST cannot be
+   readily transported over constrained (6LoWPAN, LLN) wireless
+   networks, this document defines the use of CoAP Block-Wise Transfer
+   ("Block") [<a href="./rfcmarkup.sh?rfc=7959" title='"Block-Wise Transfers in the Constrained Application Protocol (CoAP)"'>RFC7959</a>] to fragment EST messages at the application
+   layer.
+
+   Support for Observe CoAP options [<a href="./rfcmarkup.sh?rfc=7641" title='"Observing Resources in the Constrained Application Protocol (CoAP)"'>RFC7641</a>] in Blocks with BRSKI is
+   not supported in the current BRSKI/EST message flows and is thus out-
+   of-scope for this discussion.  Observe options could be used by the
+   server to notify clients about a change in the cacerts or csr
+   attributes (resources) and might be an area of future work.
+
+<span class="h2"><a name="section-2">2</a>.  Terminology</span>
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [<a href="./rfcmarkup.sh?rfc=2119" title='"Key words for use in RFCs to Indicate Requirement Levels"'>RFC2119</a>].
+
+   All the terminology from EST [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>] is included in this document
+   by reference.
+
+<span class="h2"><a name="section-3">3</a>.  EST/BRSKI operational differences</span>
+
+   Only the differences to EST and BRSKI with respect to operational
+   scenarios are described in this section.  EST-coaps server
+   authentication differs from EST as follows:
+
+   o  Replacement of TLS by a secure transport protocol and HTTP by
+      CoAP, resulting in:
+
+      *  DTLS-secured CoAP sessions between EST-coaps client and EST-
+         coaps server.
+
+   o  Only certificate-based client authentication is supported, which
+      results in:
+
+      *  The EST-coaps client does not support HTTP Basic authentication
+         (as described in <a href="./rfcmarkup.sh?rfc=7030#section-4.4.1">Section&nbsp;4.4.1 of [RFC7030]</a>)
+
+   o  EST-coaps does not support full PKI request messages[RFC5272].
+
+<span class="h2"><a name="section-4">4</a>.  Protocol Design and Layering</span>
+
+   EST-coaps uses CoAP to transfer EST messages, aided by Block-Wise
+   Transfer [<a href="./rfcmarkup.sh?rfc=7959" title='"Block-Wise Transfers in the Constrained Application Protocol (CoAP)"'>RFC7959</a>] to transport CoAP messages in blocks thus avoiding
+   (excessive) 6LoWPAN fragmentation of UDP datagrams.  The use of
+   "Block" for the transfer of larger EST messages is specified in
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 4]</span>
+</pre><pre class='newpage'><a name="page-5" id="page-5" href="#page-5" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   <a href="#section-4.3">Section 4.3</a>.  The Figure 1 below shows the layered EST-coaps
+   architecture.
+
+   +------------------------------------------------+
+   |    EST request/response messages               |
+   +------------------------------------------------+
+   |    CoAP for message transfer and signaling     |
+   +------------------------------------------------+
+   |    Secure Transport Protocol (DTLS, ...)       |
+   +------------------------------------------------+
+   |    UDP for transport                           |
+   +------------------------------------------------+
+
+                    Figure 1: EST-coaps protocol layers
+
+   The EST-coaps protocol design follows closely the EST design,
+   excluding some aspects that are not relevant for automatic
+   bootstrapping of constrained devices within a professional context.
+   The parts supported by EST-coaps are:
+
+   Message types:
+
+      *  Simple enroll and reenroll.
+
+      *  CA certificate retrieval.
+
+      *  CSR Attributes request messages.
+
+      *  Server-side key generation messages.
+
+   The EST-coaps server URIs are identical to the EST URI (except for
+   replacing the scheme https by coaps):
+
+   coaps://www.example.com/.well-known/est
+   coaps://www.example.com/.well-known/est/arbitraryLabel1
+
+   Figure 5 in <a href="./rfcmarkup.sh?rfc=7030#section-3.2.2">section&nbsp;3.2.2 of [RFC7030]</a> addresses he path URIs
+   (operations) are supported by EST.
+
+   The content-format (media type equivalent) of the CoAP message
+   determines which EST message is transported in the CoAP payload.  The
+   media types specified in the HTTP Content-Type header(see <a href="#section-3.2.2">section</a>
+   <a href="#section-3.2.2">3.2.2</a> of [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>]) are in EST-coaps specified by the Content-Format
+   Option (12) of CoAP.  The combination of URI path-suffix and content-
+   format used MUST map to an allowed combination of path-suffix and
+   media type as defined for EST.  The required content-formats for
+   these request and response messages are defined in <a href="#section-8">Section 8</a>.  The
+   CoAP response codes are defined in <a href="#section-4.2">Section 4.2</a>.
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 5]</span>
+</pre><pre class='newpage'><a name="page-6" id="page-6" href="#page-6" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   EST-coaps is designed for use between low-resource devices using CoAP
+   and hence does not need to send base64-encoded data.  Simple binary
+   coding is more efficient (30% less payload compared to base64) and
+   well supported by CoAP.  Therefore, the content formats specification
+   in <a href="#section-8">Section 8</a> requires the use of binary encoding for all EST-coaps
+   CoAP payloads.  [EDNOTE: Revisit the binary format. ]
+
+<span class="h3"><a name="section-4.1">4.1</a>.  Message Bindings</span>
+
+   This section describes BRSKI to CoAP message mappings.
+
+   CoAP defines confirmed (CON), acknowledgements (ACK), reset (RST) and
+   non-corfirmed (NON) message types.  For confirmable messages, the
+   responses are CoAP ACKs or RSTs.  All /cacerts, /simpleenroll,
+   /simplereenroll, /csrattrs and /serverkeygen EST messages expect a
+   response, so they are all COAP CON messages.
+
+   A CoAP message has the following fields ([<a href="./rfcmarkup.sh?rfc=7252" title='"The Constrained Application Protocol (CoAP)"'>RFC7252</a>]):
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |Ver| T |  TKL  |      Code     |          Message ID           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Token (if any, TKL bytes) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Options (if any) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 1 1 1 1 1 1 1|    Payload (if any) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Then Ver, TKL, Token, Message ID are not affected in BRSKI.  Their
+   use is the same as in CoAP.
+
+   The options that can be used in a CoAP header have the following
+   format:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 6]</span>
+</pre><pre class='newpage'><a name="page-7" id="page-7" href="#page-7" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+               0   1   2   3   4   5   6   7
+      +---------------+---------------+
+      |  Option Delta | Option Length |   1 byte
+      +---------------+---------------+
+      /         Option Delta          /   0-2 bytes
+      \          (extended)           \
+      +-------------------------------+
+      /         Option Length         /   0-2 bytes
+      \          (extended)           \
+      +-------------------------------+
+      \                               \
+      /         Option Value          /   0 or more bytes
+      \                               \
+      +-------------------------------+
+
+   Options are used to convey Uri-Host, Uri-Path, Uri-Port, Content-
+   Format and more in COAP.  For BRSKI, COAP Options are used to
+   communicate the HTTP fields used in the BRSKI REST messages.
+
+   BRSKI URLs are HTTPS based (https:// ), in CoAP these will be assumed
+   to be transformed to coaps (coaps://)
+
+   Some examples of how an BRSKI message would be translated in CoAP
+   follow.  [EDNOTE: This section to be expanded to ensure it covers all
+   BRSKI edge conditions.]  <a href="#appendix-A">Appendix A</a> includes some practical examples
+   of EST messages translated to COAP.  [EDNOTE: This section to be
+   expanded.
+
+<span class="h3"><a name="section-4.2">4.2</a>.  CoAP response codes</span>
+
+   <a href="./rfcmarkup.sh?rfc=7252#section-5.9">Section&nbsp;5.9 of [RFC7252]</a> specifies the mapping of HTTP response codes
+   to CoAP response codes.  Every time the HTTP response code 200 is
+   specified in [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>] in response to a GET request, in EST-coaps the
+   equivalent CoAP response code 2.05 MUST be used.  Response code HTTP
+   202 in EST is mapped as indicated below; while other HTTP 2xx
+   response codes are not used by EST.  For the following HTTP 4xx error
+   codes that may occur: 400, 401, 403, 404, 405, 406, 412, 413, 415 ;
+   the equivalent CoAP response code for EST-coaps is 4.xx.  For the
+   HTTP 5xx error codes: 500, 501, 502, 503, 504 the equivalent CoAP
+   response code is 5.xx.
+
+   HTTP response code 202 needs a different treatment from the one
+   described for [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>].  A new CoAP response code 2.06 is needed.
+   When the EST over CoAP request cannot be treated immediately, a CoAP
+   response code 2.06 Delayed is returned with Content-Format:
+   application/link-format described in [<a href="./rfcmarkup.sh?rfc=6690" title='"Constrained RESTful Environments (CoRE) Link Format"'>RFC6690</a>].  The payload of the
+   response contains a link to receive the delayed response.
+   ALTERNATIVE (to discuss) : a 2.06 Delayed response without payload
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 7]</span>
+</pre><pre class='newpage'><a name="page-8" id="page-8" href="#page-8" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   and the link to receive the delayed response indicated using the
+   Location-Path and Location-Query Options.
+
+   The waiting client may send GET requests to the returned link.  When
+   the response is not available, the server returns response code 2.06
+   with again the link for the client to query.  When the response is
+   available, the server returns the response code 2.05 Content with a
+   payload containing the requested response in the appropriate content
+   format.
+
+   <a href="#appendix-A">Appendix A</a> includes some practical examples of HTTP response codes
+   from EST translated to COAP.
+
+<span class="h3"><a name="section-4.3">4.3</a>.  Message fragmentation</span>
+
+   DTLS defines fragmentation only for the handshake part and not for
+   secure data exchange (DTLS records).  [<a href="./rfcmarkup.sh?rfc=6347" title='"Datagram Transport Layer Security Version 1.2"'>RFC6347</a>] states "Each DTLS
+   record MUST fit within a single datagram".  In order to avoid using
+   IP fragmentation, which is not supported by 6LoWPAN, invokers of the
+   DTLS record layer MUST size DTLS records so that they fit within any
+   Path MTU estimates obtained from the record layer.  In addition,
+   invokers residing on a 6LoWPAN over IEEE 802.15.4 network SHOULD
+   attempt to size CoAP messages such that each DTLS record will fit
+   within one or two IEEE 802.15.4 frames.
+
+   That is not always possible.  Even though ECC certificates are small
+   in size, they can vary greatly based on signature algorithms, key
+   sizes, and OID fields used.  For 256-bit curves, common ECDSA cert
+   sizes are 500-1000 bytes which could fluctuate further based on the
+   algorithms, OIDs, SANs and cert fields.  For 384-bit curves, ECDSA
+   certs increase in size and can sometimes reach 1.5KB.  Additionally,
+   there are times when the EST cacert response from the server can
+   include multiple certs that amount large payloads.  CoAP [<a href="./rfcmarkup.sh?rfc=7252" title='"The Constrained Application Protocol (CoAP)"'>RFC7252</a>]'s
+   <a href="#section-4.6">section 4.6</a> describes the possible payload sizes: "if nothing is
+   known about the size of the headers, good upper bounds are 1152 bytes
+   for the message size and 1024 bytes for the payload size".  Also "If
+   IPv4 support on unusual networks is a consideration, implementations
+   may want to limit themselves to more conservative IPv4 datagram sizes
+   such as 576 bytes; per [<a href="./rfcmarkup.sh?rfc=0791">RFC0791</a>], the absolute minimum value of the
+   IP MTU for IPv4 is as low as 68 bytes, which would leave only 40
+   bytes minus security overhead for a UDP payload".  Thus, even with
+   ECC certs, EST-coaps messages can still exceed sizes in MTU of 1280
+   for IPv6 or 60-80 bytes for 6LoWPAN [<a href="./rfcmarkup.sh?rfc=4919" title='"IPv6 over Low-Power Wireless Personal Area Networks (6LoWPANs): Overview, Assumptions, Problem Statement, and Goals"'>RFC4919</a>] as explained in <a href="#section-2">section</a>
+   <a href="#section-2">2</a> of [<a href="./rfcmarkup.sh?rfc=7959" title='"Block-Wise Transfers in the Constrained Application Protocol (CoAP)"'>RFC7959</a>].  EST-coaps needs to be able to fragment EST messages
+   into multiple DTLS datagrams with each DTLS datagram.  Fine-grained
+   fragmentation of EST messages is essential.
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 8]</span>
+</pre><pre class='newpage'><a name="page-9" id="page-9" href="#page-9" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   To perform fragmentation in COAP, [<a href="./rfcmarkup.sh?rfc=7959" title='"Block-Wise Transfers in the Constrained Application Protocol (CoAP)"'>RFC7959</a>] specifies the "Block1"
+   option for fragmentation of the request payload and the "Block2"
+   option for fragmentation of the return payload of a COAP flow.
+   Block1 options are used by the client PUT and POST requests.  A
+   Block1 in a client request requires a Block1 option in the responses.
+   A Block2 comes from a server response that will also need Block2 from
+   the client to acknowledge the block and get the rest of blocks from
+   the server.  Block1 is used when a request (POST for example) is used
+   with a payload that needs fragmentation.  The server responds with
+   Block1 option to acknowledge the fragment-blocks.  Block2 is used
+   when a BRSKI server response is big and needs fragmentation.  The
+   Block2 acknowledgements are requests with the same options as the
+   initial request and a Block2 option.  "To influence the block size
+   used in a response, the requester MAY also use the Block2 Option on
+   the initial request, giving the desired size, a block number of zero
+   and an M bit of zero".  The CoAP client MAY specify the Block1 size
+   and MAY also specify the Block2 size.  The CoAP server MAY specify
+   the Block2 size, but not the Block1 size.  As explained in <a href="./rfcmarkup.sh?rfc=7959#section-1">Section&nbsp;1
+   of [RFC7959]</a>), blockwise transfers SHOULD be used in Confirmable COAP
+   messages to avoid the exacerbation of lost blocks.
+
+   In a scenario with a big BRSKI POST request we might have Block1
+   options from client to server and Block2 from server to client.  In
+   this case the Block1 blocks get completed and then the Block2 flows
+   the opposite direction.
+
+   The BLOCK draft also defines Size1 and Size2 options.  These are used
+   to convey the size of the resources in the requests or responses.
+   The Size1 response MAY be parsed by the client as an size indication
+   of the Block2 resource in the server response or by the server as a
+   request for a size estimate by the client.  Similarly, Size2 option
+   defined in BLOCK should be parsed by the server as an indication of
+   the size of the resource carried in Block1 options and by the client
+   as a maximum size expected in the 4.13 (Request Entity Too Large)
+   response to a request.
+
+   Block options in CoAP messages can contain fields, SZX, M and NUM
+   which are not affected by BRSKI.
+
+   Examples of fragmented messages are shown in <a href="#appendix-B">Appendix B</a>.
+
+<span class="h2"><a name="section-5">5</a>.  Transport Protocol</span>
+
+   EST-coaps depends on a secure transport mechanism over UDP that can
+   secure (confidentiality, authenticity) the COAP messages exchanged.
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                 [Page 9]</span>
+</pre><pre class='newpage'><a name="page-10" id="page-10" href="#page-10" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+<span class="h3"><a name="section-5.1">5.1</a>.  DTLS</span>
+
+   DTLS is one such secure protocol.  Within BRSKI and EST when "TLS" is
+   referred to, it is understood that in EST-coaps, security is provided
+   using DTLS instead.  No other changes are necessary (all provisional
+   modes etc are the same as for TLS).
+
+   COAP was designed to avoid fragmentation.  DTLS is used to secure
+   COAP messages.  When using DTLS, even though it can be avoided by
+   using pre-shared keys or ECC ciphersuites, sometimes fragmentation
+   will be needed.  During the DTLS handshake, if fragmentation is
+   necessary, "DTLS provides a mechanism for fragmenting a handshake
+   message over a number of records, each of which can be transmitted
+   separately, thus avoiding IP fragmentation" [<a href="./rfcmarkup.sh?rfc=6347" title='"Datagram Transport Layer Security Version 1.2"'>RFC6347</a>].
+
+   The EST-coaps client MUST be configured with an explicit TA database
+   at least an implicit TA database from its manufacturer.  The
+   authentication of the EST-coaps server by the EST-coaps client is
+   based on Certificate authentication in the DTLS handshake.
+
+   The authentication of the EST-coaps client is based on client
+   certificate in the DTLS handshake.  This can either be
+
+   o  DTLS with a previously issued client certificate (e.g., an
+      existing certificate issued by the EST CA);
+
+   o  DTLS with a previously installed certificate (e.g., manufacturer-
+      installed certificate or a certificate issued by some other
+      party);
+
+   The details on checking the validity of the certificates are
+   identical to EST.
+
+   EST-coaps does not support full PKI Requests.  Consequently, the
+   fullcmc request of <a href="./rfcmarkup.sh?rfc=7030#section-4.3">section&nbsp;4.3 of [RFC7030]</a> and response MUST NOT be
+   supported by EST-coaps.
+
+   Channel-binding information for linking proof-of-identity with
+   message-based proof-of-possession (OPTIONAL).  Given that CoAP and
+   DTLS can provide proof of identity for EST-coaps clients and server,
+   simple PKI messages can be used conformant to <a href="./rfcmarkup.sh?rfc=5272#section-3.1">section&nbsp;3.1 of
+   [RFC5272]</a>.  EST-coaps supports the certificate types and Trust
+   Anchors (TA) that are specified for EST in <a href="./rfcmarkup.sh?rfc=7030#section-3">section&nbsp;3 of [RFC7030]</a>.
+   [EDNOTE: To describe POP in the DTLS context]
+
+   In a constrained CoAP environment, endpoints can't afford to
+   establish a DTLS connection for every EST transaction.
+   Authenticating and negotiating DTLS keys requires resources on low-
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 10]</span>
+</pre><pre class='newpage'><a name="page-11" id="page-11" href="#page-11" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   end endpoints and consumes valuable bandwidth.  The DTLS connection
+   SHOULD remain open for persistent EST connections.  For example, an
+   EST cacerts request that is followed by a simpleenroll request can
+   use the same authenticated DTLS connection.  Given that after a
+   successful enrollment, it is more likely that a new EST transaction
+   will take place after a significant amount of time, the DTLS
+   connections SHOULD only be kept alive for EST messages that are
+   relatively close to each other.
+
+   The mandatory cipher suite for DTLS is
+   TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 defined in [<a href="./rfcmarkup.sh?rfc=7251" title='"AES- CCM Elliptic Curve Cryptography (ECC) Cipher Suites for TLS"'>RFC7251</a>] which is the
+   mandatory-to-implement cipher suite in CoAP.  Additionally the curve
+   secp256r1 MUST be supported [<a href="./rfcmarkup.sh?rfc=4492" title='"Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)"'>RFC4492</a>]; this curve is equivalent to
+   the NIST P-256 curve.  The hash algorithm is SHA-256.  DTLS
+   implementations MUST use the Supported Elliptic Curves and Supported
+   Point Formats Extensions [<a href="./rfcmarkup.sh?rfc=4492" title='"Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)"'>RFC4492</a>]; the uncompressed point format
+   MUST be supported; [<a href="./rfcmarkup.sh?rfc=6090" title='"Fundamental Elliptic Curve Cryptography Algorithms"'>RFC6090</a>] can be used as an implementation method.
+
+<span class="h3"><a name="section-5.2">5.2</a>.  [EDNOTE: Placeholder]</span>
+
+   [EDNOTE: Other secure transport mechanisms placeholder section. ]
+
+<span class="h2"><a name="section-6">6</a>.  Proxying</span>
+
+   [EDNOTE: This section to be populated.  It will address how proxying
+   can take place by an entity that resides at the edge of the CoAP
+   network, such as the Registrar, and can reach the BRSKI server
+   residing in a traditional "TCP setting". ]
+
+<span class="h2"><a name="section-7">7</a>.  Parameters</span>
+
+   [EDNOTE: This section to be populated.  It will address transmission
+   parameters for BRSKI described in sections <a href="#section-4.7">4.7</a> and <a href="#section-4.8">4.8</a> of the CoAP
+   draft.  BRSKI does not impose any unique parameters that affect the
+   CoAP parameters in Table 2 and 3 in the CoAP draft but the ones in
+   CoAP could be affecting BRSKI.  For example the processing delay of
+   CAs could be less then 2s, but in this case they should send an CoAP
+   ACK every 2s while processing.]
+
+<span class="h2"><a name="section-8">8</a>.  IANA Considerations</span>
+
+   Additions to the sub-registry "CoAPContent-Formats", within the "CoRE
+   Parameters" registry are needed for the below media types.  These can
+   be registered either in the Expert Review range (0-255) or IETF
+   Review range (256-9999).
+
+   1.
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 11]</span>
+</pre><pre class='newpage'><a name="page-12" id="page-12" href="#page-12" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+       *  application/pkcs7-mime
+
+       *  Type name: application
+
+       *  Subtype name: pkcs7-mime
+
+       *  smime-type: certs-only
+
+       *  ID: TBD1
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [<a href="./rfcmarkup.sh?rfc=5751" title='"Secure/Multipurpose Internet Mail Extensions (S/MIME) Version 3.2 Message Specification"'>RFC5751</a>]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   2.
+
+       *  application/pkcs8
+
+       *  Type name: application
+
+       *  Subtype name: pkcs8
+
+       *  ID: TBD2
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [<a href="./rfcmarkup.sh?rfc=5958" title='"Asymmetric Key Packages"'>RFC5958</a>]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   3.
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 12]</span>
+</pre><pre class='newpage'><a name="page-13" id="page-13" href="#page-13" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+       *  application/csrattrs
+
+       *  Type name: application
+
+       *  Subtype name: csrattrs
+
+       *  ID: TBD3
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   4.
+
+       *  application/pkcs10
+
+       *  Type name: application
+
+       *  Subtype name: pkcs10
+
+       *  ID: TBD4
+
+       *  Required paraeters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [<a href="./rfcmarkup.sh?rfc=5967" title='"The application/pkcs10 Media Type"'>RFC5967</a>]
+
+       *  Applications that use this media type: ANIMA bootstrap (BRSKI)
+          and EST
+
+   Additions to the sub-registry "CoAP Response Code", within the "CoRE
+   Parameters" registry are needed for the following response codes:
+
+   o  Code: 2.06
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 13]</span>
+</pre><pre class='newpage'><a name="page-14" id="page-14" href="#page-14" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   o  Description: Delayed
+
+   o  Reference: this document
+
+   [EDNOTE: This section will be expanded to includes types needed that
+   do not exist in COAP.]
+
+<span class="h2"><a name="section-9">9</a>.  Security Considerations</span>
+
+   [EDNOTE: This section to be populated.  This document describes an
+   existing protocol moved to CoAP and there should not be additional
+   security concerns added beyond the protocol's or CoAP's specifics
+   security considerations.  The security considerations mentioned in
+   EST applies also to EST-coaps.  Specifically for server-side key
+   generation, it introduces implications for the endpoints and their
+   private keys, which will be covered here. ]
+
+<span class="h2"><a name="section-10">10</a>.  Acknowledgements</span>
+
+   The authors are very grateful to Klaus Hartke for his detailed
+   explanations on the use of Block with DTLS.  The authors would like
+   to thank Esko Dijk and Michael Verschoor for the valuable discussions
+   that helped in shaping the solution.  They would also like to thank
+   Peter Panburana from Cisco for his feedback on technical details of
+   the solution.
+
+<span class="h2"><a name="section-11">11</a>.  Change Log</span>
+
+   -01:
+
+      Merging of <a href="./rfcmarkup.sh?draft=draft-vanderstok-ace-coap-est-00">draft-vanderstok-ace-coap-est-00</a> and <a href="./rfcmarkup.sh?draft=draft-vanderstok-ace-coap-est-01">draft-vanderstok-</a>
+      <a href="./rfcmarkup.sh?draft=draft-vanderstok-ace-coap-est-01">ace-coap-est-01</a>
+
+<span class="h2"><a name="section-12">12</a>.  References</span>
+
+<span class="h3"><a name="section-12.1">12.1</a>.  Normative References</span>
+
+   [<a name="ref-I-D.ietf-anima-bootstrapping-keyinfra" id="ref-I-D.ietf-anima-bootstrapping-keyinfra">I-D.ietf-anima-bootstrapping-keyinfra</a>]
+              Pritikin, M., Richardson, M., Behringer, M., Bjarnason,
+              S., and K. Watsen, "Bootstrapping Remote Secure Key
+              Infrastructures (BRSKI)", <a href="./rfcmarkup.sh?draft=draft-ietf-anima-bootstrapping-keyinfra-04">draft-ietf-anima-bootstrapping-</a>
+              <a href="./rfcmarkup.sh?draft=draft-ietf-anima-bootstrapping-keyinfra-04">keyinfra-04</a> (work in progress), October 2016.
+
+   [<a name="ref-RFC2119" id="ref-RFC2119">RFC2119</a>]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", <a href="./rfcmarkup.sh?bcp=14">BCP 14</a>, <a href="./rfcmarkup.sh?rfc=2119">RFC 2119</a>,
+              DOI 10.17487/RFC2119, March 1997,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc2119">http://www.rfc-editor.org/info/rfc2119</a>&gt;.
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 14]</span>
+</pre><pre class='newpage'><a name="page-15" id="page-15" href="#page-15" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   [<a name="ref-RFC5272" id="ref-RFC5272">RFC5272</a>]  Schaad, J. and M. Myers, "Certificate Management over CMS
+              (CMC)", <a href="./rfcmarkup.sh?rfc=5272">RFC 5272</a>, DOI 10.17487/RFC5272, June 2008,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc5272">http://www.rfc-editor.org/info/rfc5272</a>&gt;.
+
+   [<a name="ref-RFC5751" id="ref-RFC5751">RFC5751</a>]  Ramsdell, B. and S. Turner, "Secure/Multipurpose Internet
+              Mail Extensions (S/MIME) Version 3.2 Message
+              Specification", <a href="./rfcmarkup.sh?rfc=5751">RFC 5751</a>, DOI 10.17487/RFC5751, January
+              2010, &lt;<a href="http://www.rfc-editor.org/info/rfc5751">http://www.rfc-editor.org/info/rfc5751</a>&gt;.
+
+   [<a name="ref-RFC5967" id="ref-RFC5967">RFC5967</a>]  Turner, S., "The application/pkcs10 Media Type", <a href="./rfcmarkup.sh?rfc=5967">RFC 5967</a>,
+              DOI 10.17487/RFC5967, August 2010,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc5967">http://www.rfc-editor.org/info/rfc5967</a>&gt;.
+
+   [<a name="ref-RFC6347" id="ref-RFC6347">RFC6347</a>]  Rescorla, E. and N. Modadugu, "Datagram Transport Layer
+              Security Version 1.2", <a href="./rfcmarkup.sh?rfc=6347">RFC 6347</a>, DOI 10.17487/RFC6347,
+              January 2012, &lt;<a href="http://www.rfc-editor.org/info/rfc6347">http://www.rfc-editor.org/info/rfc6347</a>&gt;.
+
+   [<a name="ref-RFC6690" id="ref-RFC6690">RFC6690</a>]  Shelby, Z., "Constrained RESTful Environments (CoRE) Link
+              Format", <a href="./rfcmarkup.sh?rfc=6690">RFC 6690</a>, DOI 10.17487/RFC6690, August 2012,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc6690">http://www.rfc-editor.org/info/rfc6690</a>&gt;.
+
+   [<a name="ref-RFC7030" id="ref-RFC7030">RFC7030</a>]  Pritikin, M., Ed., Yee, P., Ed., and D. Harkins, Ed.,
+              "Enrollment over Secure Transport", <a href="./rfcmarkup.sh?rfc=7030">RFC 7030</a>,
+              DOI 10.17487/RFC7030, October 2013,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7030">http://www.rfc-editor.org/info/rfc7030</a>&gt;.
+
+   [<a name="ref-RFC7252" id="ref-RFC7252">RFC7252</a>]  Shelby, Z., Hartke, K., and C. Bormann, "The Constrained
+              Application Protocol (CoAP)", <a href="./rfcmarkup.sh?rfc=7252">RFC 7252</a>,
+              DOI 10.17487/RFC7252, June 2014,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7252">http://www.rfc-editor.org/info/rfc7252</a>&gt;.
+
+   [<a name="ref-RFC7959" id="ref-RFC7959">RFC7959</a>]  Bormann, C. and Z. Shelby, Ed., "Block-Wise Transfers in
+              the Constrained Application Protocol (CoAP)", <a href="./rfcmarkup.sh?rfc=7959">RFC 7959</a>,
+              DOI 10.17487/RFC7959, August 2016,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7959">http://www.rfc-editor.org/info/rfc7959</a>&gt;.
+
+<span class="h3"><a name="section-12.2">12.2</a>.  Informative References</span>
+
+   [<a name="ref-ieee802.15.4" id="ref-ieee802.15.4">ieee802.15.4</a>]
+              Institute of Electrical and Electronics Engineers, , "IEEE
+              Standard 802.15.4-2006", 2006.
+
+   [<a name="ref-RFC4492" id="ref-RFC4492">RFC4492</a>]  Blake-Wilson, S., Bolyard, N., Gupta, V., Hawk, C., and B.
+              Moeller, "Elliptic Curve Cryptography (ECC) Cipher Suites
+              for Transport Layer Security (TLS)", <a href="./rfcmarkup.sh?rfc=4492">RFC 4492</a>,
+              DOI 10.17487/RFC4492, May 2006,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc4492">http://www.rfc-editor.org/info/rfc4492</a>&gt;.
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 15]</span>
+</pre><pre class='newpage'><a name="page-16" id="page-16" href="#page-16" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   [<a name="ref-RFC4919" id="ref-RFC4919">RFC4919</a>]  Kushalnagar, N., Montenegro, G., and C. Schumacher, "IPv6
+              over Low-Power Wireless Personal Area Networks (6LoWPANs):
+              Overview, Assumptions, Problem Statement, and Goals",
+              <a href="./rfcmarkup.sh?rfc=4919">RFC 4919</a>, DOI 10.17487/RFC4919, August 2007,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc4919">http://www.rfc-editor.org/info/rfc4919</a>&gt;.
+
+   [<a name="ref-RFC4944" id="ref-RFC4944">RFC4944</a>]  Montenegro, G., Kushalnagar, N., Hui, J., and D. Culler,
+              "Transmission of IPv6 Packets over IEEE 802.15.4
+              Networks", <a href="./rfcmarkup.sh?rfc=4944">RFC 4944</a>, DOI 10.17487/RFC4944, September 2007,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc4944">http://www.rfc-editor.org/info/rfc4944</a>&gt;.
+
+   [<a name="ref-RFC5246" id="ref-RFC5246">RFC5246</a>]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", <a href="./rfcmarkup.sh?rfc=5246">RFC 5246</a>,
+              DOI 10.17487/RFC5246, August 2008,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc5246">http://www.rfc-editor.org/info/rfc5246</a>&gt;.
+
+   [<a name="ref-RFC5958" id="ref-RFC5958">RFC5958</a>]  Turner, S., "Asymmetric Key Packages", <a href="./rfcmarkup.sh?rfc=5958">RFC 5958</a>,
+              DOI 10.17487/RFC5958, August 2010,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc5958">http://www.rfc-editor.org/info/rfc5958</a>&gt;.
+
+   [<a name="ref-RFC6090" id="ref-RFC6090">RFC6090</a>]  McGrew, D., Igoe, K., and M. Salter, "Fundamental Elliptic
+              Curve Cryptography Algorithms", <a href="./rfcmarkup.sh?rfc=6090">RFC 6090</a>,
+              DOI 10.17487/RFC6090, February 2011,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc6090">http://www.rfc-editor.org/info/rfc6090</a>&gt;.
+
+   [<a name="ref-RFC7230" id="ref-RFC7230">RFC7230</a>]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Message Syntax and Routing",
+              <a href="./rfcmarkup.sh?rfc=7230">RFC 7230</a>, DOI 10.17487/RFC7230, June 2014,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7230">http://www.rfc-editor.org/info/rfc7230</a>&gt;.
+
+   [<a name="ref-RFC7251" id="ref-RFC7251">RFC7251</a>]  McGrew, D., Bailey, D., Campagna, M., and R. Dugal, "AES-
+              CCM Elliptic Curve Cryptography (ECC) Cipher Suites for
+              TLS", <a href="./rfcmarkup.sh?rfc=7251">RFC 7251</a>, DOI 10.17487/RFC7251, June 2014,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7251">http://www.rfc-editor.org/info/rfc7251</a>&gt;.
+
+   [<a name="ref-RFC7641" id="ref-RFC7641">RFC7641</a>]  Hartke, K., "Observing Resources in the Constrained
+              Application Protocol (CoAP)", <a href="./rfcmarkup.sh?rfc=7641">RFC 7641</a>,
+              DOI 10.17487/RFC7641, September 2015,
+              &lt;<a href="http://www.rfc-editor.org/info/rfc7641">http://www.rfc-editor.org/info/rfc7641</a>&gt;.
+
+<span class="h2"><a name="appendix-A">Appendix A</a>.  EST messages to EST-coaps</span>
+
+<span class="h1"><a name="appendix-A.1">A.1</a>.  cacerts</span>
+
+   In EST, an HTTPS cacerts message can be
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 16]</span>
+</pre><pre class='newpage'><a name="page-17" id="page-17" href="#page-17" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+     GET /.well-known/est/cacerts HTTP/1.1
+        User-Agent: curl/7.22.0 (i686-pc-linux-gnu) libcurl/7.22.0
+                    OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
+        Host: 192.0.2.1:8085
+        Accept: */*
+
+   The corresponding CoAP request is
+
+   REQ:
+           GET coaps://[192.0.2.1:8085]/.well-known/est/cacerts
+
+   with COAP fields
+
+     Ver = 1
+     T = 0 (CON)
+     Code = 0x01 (0.01 is GET)
+     Options
+      Option1 (Uri-Host)
+        Option Delta = 0x3
+        Option Length = 0x9
+        Option Value = 192.0.2.1
+      Option2 (Uri-Port)
+        Option Delta = 0xA
+        Option Length = 0x4
+        Option Value = 8085
+      Option3 (Uri-Path)
+        Option Delta = 0xD
+        Option Length = 0xD
+        Extended Option Delta = 0x08
+        Extended Option Length = 0x14
+        Option Value = /.well-known/est/cacerts HTTP/1.1
+     Payload = [Empty]
+
+   A 200 OK response with a cert in EST will them be
+
+      HTTP/1.1 200 OK
+      Status: 200 OK
+      Content-Type: application/pkcs7-mime
+      Content-Transfer-Encoding: base64 [EDNOTE: Verify if we need a new
+                                         option registry for Encoding?)
+      Content-Length: 4246 [EDNOTE: this example overflows and would
+                            need fragmentation. Choose a better example.
+                            Regardless we might need an CoAP option for
+                            the content-length ie the CoAP payload?)
+
+      MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExADALBgkqhkiG9w0BBwGgggwMMIIC
+      +zCCAeOgAwIBAgIJAJpY3nUZO3qcMA0GCSqGSIb3DQEBBQUAMBsxGTAXBgNVBAMT
+      ...
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 17]</span>
+</pre><pre class='newpage'><a name="page-18" id="page-18" href="#page-18" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   The corresponding CoAP response is
+
+   RES:
+           2.05 Content (Content-Format: application/pkcs7-mime)
+           {payload}
+
+   with COAP fields
+
+    Ver = 1
+    T = 2 (ACK)
+    Code = 0x21 [EDNOTE: Maybe we need to create a 0x200 response code.)
+    Options
+      Option1 (Content-Format)
+        Option Delta = 0xC
+        Option Length = 0xD
+        Extended Option Length = 0x09
+        Option Value = &lt;number for application/pkcs7-mime&gt;
+                  [EDNOTE: We need a new CoAP IANA registered value
+                  application/pkcs7-mime; smime-type=certs-only,
+                  application/csrattrs, application/pkcs10,
+                  application/pkcs8,
+                  application/pkcs12 )
+    Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExA \
+                DALBgkqhkiG9w0BBwGgggwMMIIC...
+
+<span class="h1"><a name="appendix-A.2">A.2</a>.  enroll / reenroll</span>
+
+   [EDNOTE: username/password authentication can be described here but
+   is not a primary focus for BRSKI.  It is important for generic EST
+   exchanges but would an endpoint device with sufficient user interface
+   to allow username/password input from an end user be required to use
+   CoAP instead of a full HTTPS exchange?]
+
+   [EDNOTE: We might need a new Option for the Retry-After response
+   message.  We might need a new Option for the WWW-Authenticate
+   response.]
+
+   [EDNOTE: Include COAP message examples. ]
+
+<span class="h1"><a name="appendix-A.3">A.3</a>.  csrattr</span>
+
+   [EDNOTE: Include COAP message examples. ]
+
+<span class="h1"><a name="appendix-A.4">A.4</a>.  enrollstatus</span>
+
+   [EDNOTE: Include COAP message examples. ]
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 18]</span>
+</pre><pre class='newpage'><a name="page-19" id="page-19" href="#page-19" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+<span class="h1"><a name="appendix-A.5">A.5</a>.  voucher_status</span>
+
+   [EDNOTE: Include COAP message examples. ]
+
+<span class="h1"><a name="appendix-A.6">A.6</a>.  requestvoucher</span>
+
+   [EDNOTE: Include COAP message examples. ]
+
+<span class="h1"><a name="appendix-A.7">A.7</a>.  requestlog</span>
+
+   [EDNOTE: Include COAP message examples. ]
+
+   [EDNOTE: More examples can be added, for server-side key generation
+   in CMS envelopes. ]
+
+<span class="h2"><a name="appendix-B">Appendix B</a>.  EST-coaps Block message examples</span>
+
+   This section provides detailed examples of the messages using DTLS
+   and BLOCK option Block2.  The minimum PMTU is 1280 bytes, which is
+   the example value assumed for the DTLS datagram size.  The example
+   block length is taken as 64 which gives an SZX value of 2.
+
+   The following is an example of a valid /cacerts exchange over DTLS. .
+   The content length of the cacerts response in <a href="#appendix-A.1">appendix A.1</a> of
+   [<a href="./rfcmarkup.sh?rfc=7030" title='"Enrollment over Secure Transport"'>RFC7030</a>] is 4246 bytes using base64.  This leads to a length of 3185
+   bytes in binary.  The CoAP message adds around 10 bytes, the DTLS
+   record 29 bytes.  To avoid IP fragmentation, the CoAP block option is
+   used and an MTU of 127 is assumed to stay within one IEEE 802.15.4
+   packet.  To stay below the MTU of 127, the payload is split in 50
+   packets with a payload of 64 bytes each.  The client sends an IPv6
+   packet containing the UDP datagram with the DTLS record that
+   encapsulates the CoAP Request 50 times.  The server returns an IPv6
+   packet containing the UDP datagram with the DTLS record that
+   encapsulates the CoAP response.  The CoAP request-response exchange
+   with block option is shown below.  Block option is shown in a
+   decomposed way indicating the kind of Block option (2 in this case
+   because used in the response) followed by a colon, and then the block
+   number (NUM), the more bit (M = 0 means last block), and block size
+   exponent (2**(SZX+4)) separated by slashes.  The Length 64 is used
+   with SZX= 2 to avoid IP fragmentation.  The CoAP Request is sent with
+   confirmable (CON) option and the content format of the Response is
+   /application/cacerts.
+
+
+
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 19]</span>
+</pre><pre class='newpage'><a name="page-20" id="page-20" href="#page-20" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+   GET [192.0.2.1:8085]/.well-known/est/cacerts     --&gt;
+                 &lt;--   (2:0/1/64) 2.05 Content
+       GET URI (2:1/1/64)                           --&gt;
+                 &lt;--   (2:1/1/64) 2.05 Content
+                         |
+                         |
+                         |
+        GET URI (2:49/1/64)                         --&gt;
+                 &lt;--   (2:49/0/64) 2.05 Content
+
+   An example HTTP cacerts response that exceeds the MTU can be
+
+   HTTP/1.1 200 OK
+      Status: 200 OK
+      Content-Type: application/pkcs7-mime; smime-type=certs-only
+      Content-Transfer-Encoding: base64
+      Content-Length: 1122
+
+      MIIDOAYJKoZIhvcNAQcCoIIDKTCCAyUCAQExADALBgkqhkiG9w0BBwGgggMLMIID
+      BzCCAe+gAwIBAgIBFTANBgkqhkiG9w0BAQUFADAbMRkwFwYDVQQDExBlc3RFeGFt
+      cGxlQ0EgTndOMB4XDTEzMDUwOTIzMTU1M1oXDTE0MDUwOTIzMTU1M1owHzEdMBsG
+      A1UEAxMUZGVtb3N0ZXA0IDEzNjgxNDEzNTIwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+      DwAwggEKAoIBAQClNp+kdz+Nj8XpEp9kaumWxDZ3eFYJpQKz9ddD5e5OzUeCm103
+      ZIXQIxc0eVtMCatnRr3dnZRCAxGjwbqoB3eKt29/XSQffVv+odbyw0WdkQOIbntC
+      Qry8YdcBZ+8LjI/N7M2krmjmoSLmLwU2V4aNKf0YMLR5Krmah3Ik31jmYCSvwTnv
+      6mx6pr2pTJ82JavhTEIIt/fAYq1RYhkM1CXoBL+yhEoDanN7TzC94skfS3VV+f53
+      J9SkUxTYcy1Rw0k3VXfxWwy+cSKEPREl7I6k0YeKtDEVAgBIEYM/L1S69RXTLuji
+      rwnqSRjOquzkAkD31BE961KZCxeYGrhxaR4PAgMBAAGjUjBQMA4GA1UdDwEB/wQE
+      AwIEsDAdBgNVHQ4EFgQU/qDdB6ii6icQ8wGMXvy1jfE4xtUwHwYDVR0jBBgwFoAU
+      scRp5lujBKfYl6OLO7+5arIyQjwwDQYJKoZIhvcNAQEFBQADggEBACmxg1hvL6+7
+      a+lFTARoxainBx5gxdZ9omSb0L+qL+4PDvg/+KHzKsDnMCrcU6M4YP5n0EDKmGa6
+      4lY8fbET4tt7juJg6ixb95/760Th0vuctwkGr6+D6ETTfqyHnrbhX3lAhnB+0Ja7
+      o1gv4CWxh1I8aRaTXdpOHORvN0SMXdcrlCys2vrtOl+LjR2a3kajJO6eQ5leOdzF
+      QlZfOPhaLWen0e2BLNJI0vsC2Fa+2LMCnfC38XfGALa5A8e7fNHXWZBjXZLBCza3
+      rEs9Mlh2CjA/ocSC/WxmMvd+Eqnt/FpggRy+F8IZSRvBaRUCtGE1lgDmu6AFUxce
+      R4POrT2xz8ChADEA
+
+   As another example, let's assume that the cacerts message will need
+   to be broken up to three messages.  The first Block2 will be
+
+
+
+
+
+
+
+
+
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 20]</span>
+</pre><pre class='newpage'><a name="page-21" id="page-21" href="#page-21" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+     Ver = 1
+     T = 2 (ACK)
+     Code = 0x21 (2.01 success message.
+            EDNOTE: Do we need to create a 0x200 respond code.)
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = &lt;number for application/pkcs7-mime;
+                         smime-type=certs-only&gt;
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x0D
+     Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYC \
+               AQExADALBgkqhkiG9w0BBwGgggwMMIIC... (512 bytes)
+   [EDNOTE: Potentially replace base64 with binary ]
+
+   The second Block2:
+
+     Ver = 1
+     T = 2 (means ACK)
+     Code = 0x21
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = &lt;number for application/pkcs7-mime;
+                        smime-type=certs-only&gt;
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12 ]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x1D
+     Payload = ... (512 bytes)
+
+   The third and final Block2:
+
+
+
+<span class="grey">Kumar, et al.             Expires July 22, 2017                [Page 21]</span>
+</pre><pre class='newpage'><a name="page-22" id="page-22" href="#page-22" class="invisible"> </a>
+<span class="grey">Internet-Draft                  EST-coaps                   January 2017</span>
+
+
+     Ver = 1
+     T = 2 (means ACK)
+     Code = 0x21
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = &lt;number for application/pkcs7-mime;
+                         smime-type=certs-only&gt;
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12 ]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x25
+     Payload = ...
+
+   [EDNOTE: We can add Fragmented request example with Block1 ]
+
+   [EDNOTE: Fragmented request/response example with Block1, Size1 and
+   Block2"&gt;
+
+Authors' Addresses
+
+   Sandeep S. Kumar
+   Philips Lighting Research
+   High Tech Campus 7
+   Eindhoven  5656 AE
+   NL
+
+   Email: ietf@sandeep.de
+
+
+   Peter van der Stok
+   Consultant
+
+   Email: consultancy@vanderstok.org
+
+
+   Panos Kampanakis
+   Cisco Systems
+
+   Email: pkampana@cisco.com
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 22]
+
+</pre><br />
+<span class="noprint"><small><small>Html markup produced by rfcmarkup 1.96, available from
+<a href="http://tools.ietf.org/tools/rfcmarkup/">http://tools.ietf.org/tools/rfcmarkup/</a>
+</small></small></span>
+</body></html>

--- a/draft-vanderstok-ace-coap-est-01.txt
+++ b/draft-vanderstok-ace-coap-est-01.txt
@@ -1,0 +1,1232 @@
+
+
+
+
+ACE                                                             S. Kumar
+Internet-Draft                                 Philips Lighting Research
+Intended status: Standards Track                         P. van der Stok
+Expires: July 22, 2017                                        Consultant
+                                                           P. Kampanakis
+                                                           Cisco Systems
+                                                        January 18, 2017
+
+
+                    EST over secure CoAP (EST-coaps)
+                    draft-vanderstok-ace-coap-est-00
+
+Abstract
+
+   Low-resource devices in a Low-power and Lossy Network (LLN) can
+   operate in a mesh network using the IPv6 over Low-power Personal Area
+   Networks (6LoWPAN) and IEEE 802.15.4 link-layer standards.
+   Provisioning these devices in a secure manner with keys (often called
+   security bootstrapping) used to encrypt and authenticate messages is
+   the subject of Bootstrapping of Remote Secure Key Infrastructures
+   (BRSKI) [I-D.ietf-anima-bootstrapping-keyinfra].  Enrollment over
+   Secure Transport (EST) [RFC7030], based on TLS and HTTP, is used in
+   BRSKI.  Low-resource devices often use the lightweight Constrained
+   Application Protocol (COAP) [RFC7252] for message exchanges.  This
+   document defines how low-resource devices are expected to use EST
+   over secure CoAP (EST-coaps) for secure bootstrapping and certificate
+   enrollment. 6LoWPAN fragmentation management and minor extensions to
+   CoAP are needed to enable EST-coaps.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on July 22, 2017.
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 1]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+Copyright Notice
+
+   Copyright (c) 2017 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  EST/BRSKI operational differences . . . . . . . . . . . . . .   4
+   4.  Protocol Design and Layering  . . . . . . . . . . . . . . . .   4
+     4.1.  Message Bindings  . . . . . . . . . . . . . . . . . . . .   6
+     4.2.  CoAP response codes . . . . . . . . . . . . . . . . . . .   7
+     4.3.  Message fragmentation . . . . . . . . . . . . . . . . . .   8
+   5.  Transport Protocol  . . . . . . . . . . . . . . . . . . . . .   9
+     5.1.  DTLS  . . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     5.2.  [EDNOTE: Placeholder] . . . . . . . . . . . . . . . . . .  11
+   6.  Proxying  . . . . . . . . . . . . . . . . . . . . . . . . . .  11
+   7.  Parameters  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  11
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   11. Change Log  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  14
+     12.2.  Informative References . . . . . . . . . . . . . . . . .  15
+   Appendix A.  EST messages to EST-coaps  . . . . . . . . . . . . .  16
+     A.1.  cacerts . . . . . . . . . . . . . . . . . . . . . . . . .  16
+     A.2.  enroll / reenroll . . . . . . . . . . . . . . . . . . . .  18
+     A.3.  csrattr . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     A.4.  enrollstatus  . . . . . . . . . . . . . . . . . . . . . .  18
+     A.5.  voucher_status  . . . . . . . . . . . . . . . . . . . . .  19
+     A.6.  requestvoucher  . . . . . . . . . . . . . . . . . . . . .  19
+     A.7.  requestlog  . . . . . . . . . . . . . . . . . . . . . . .  19
+   Appendix B.  EST-coaps Block message examples . . . . . . . . . .  19
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  22
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 2]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+1.  Introduction
+
+   IPv6 over Low-power Wireless Personal Area Networks (6LoWPANs)
+   [RFC4944] on IEEE 802.15.4 [ieee802.15.4] wireless networks is
+   becoming common in many industry application domains such as lighting
+   controls.  However commissioning of such networks suffers from a lack
+   of standardized secure bootstrapping mechanisms for these networks.
+
+   Although IEEE 802.15.4 defines how security can be enabled between
+   nodes within a single mesh network, it does not specify the
+   provisioning and management of the keys.  Therefore securing a
+   6LoWPAN network with devices from multiple manufacturers with
+   different provisioning techniques is often tedious and time
+   consuming.
+
+   Bootstrapping of Remote Secure Infrastructures (BRSKI)
+   [I-D.ietf-anima-bootstrapping-keyinfra] addresses the issue of
+   bootstrapping networked devices in the context of Autonomic
+   Networking Integrated Model and Approach (ANIMA).  However, BRSKI has
+   not been developed specifically for low-resource devices in
+   constrained networks.  These networks use DTLS [RFC6347], CoAP
+   [RFC7252], and UDP instead of TLS [RFC5246], HTTP [RFC7230] and TCP.
+   BRSKI relies on HTTP RESTful APIs and enrollment over Secure
+   Transport (EST) [RFC7030] for the provisioning of the operational
+   domain certificates.  Replacing the EST invocations of TLS and HTTP
+   by UDP and CoAP invocations enables applying BRSKI on CoAP-based low-
+   resource devices.
+
+   Although EST-coaps paves the way for the utilization of BRSKI and EST
+   for constrained devices on constrained networks, some devices will
+   not have enough resources to handle the large payloads that come with
+   EST-coaps.  The definition of EST-coaps is intended to ensure that
+   bootstrapping works for less constrained devices that choose to limit
+   their communications stack to UDP/CoAP.  It is up to the network
+   designer to decide which devices execute the EST protocol and which
+   not.
+
+   EST-coaps is designed for use in professional control networks such
+   as lighting.  The autonomic bootstrapping is interesting because it
+   reduces the manual intervention during the commissioning of the
+   network.  Typing in passwords is contrary to this wish.  Therefore,
+   the HTTP Basic authentication of EST is not supported in EST-coaps.
+
+   In the constrained devices context it is very unlikely that full PKI
+   request messages will be used.  For that reason, full PKI messages
+   are not supported in EST-coaps.
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 3]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   Because the relatively large messages involved in EST cannot be
+   readily transported over constrained (6LoWPAN, LLN) wireless
+   networks, this document defines the use of CoAP Block-Wise Transfer
+   ("Block") [RFC7959] to fragment EST messages at the application
+   layer.
+
+   Support for Observe CoAP options [RFC7641] in Blocks with BRSKI is
+   not supported in the current BRSKI/EST message flows and is thus out-
+   of-scope for this discussion.  Observe options could be used by the
+   server to notify clients about a change in the cacerts or csr
+   attributes (resources) and might be an area of future work.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   All the terminology from EST [RFC7030] is included in this document
+   by reference.
+
+3.  EST/BRSKI operational differences
+
+   Only the differences to EST and BRSKI with respect to operational
+   scenarios are described in this section.  EST-coaps server
+   authentication differs from EST as follows:
+
+   o  Replacement of TLS by a secure transport protocol and HTTP by
+      CoAP, resulting in:
+
+      *  DTLS-secured CoAP sessions between EST-coaps client and EST-
+         coaps server.
+
+   o  Only certificate-based client authentication is supported, which
+      results in:
+
+      *  The EST-coaps client does not support HTTP Basic authentication
+         (as described in Section 4.4.1 of [RFC7030])
+
+   o  EST-coaps does not support full PKI request messages[RFC5272].
+
+4.  Protocol Design and Layering
+
+   EST-coaps uses CoAP to transfer EST messages, aided by Block-Wise
+   Transfer [RFC7959] to transport CoAP messages in blocks thus avoiding
+   (excessive) 6LoWPAN fragmentation of UDP datagrams.  The use of
+   "Block" for the transfer of larger EST messages is specified in
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 4]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   Section 4.3.  The Figure 1 below shows the layered EST-coaps
+   architecture.
+
+   +------------------------------------------------+
+   |    EST request/response messages               |
+   +------------------------------------------------+
+   |    CoAP for message transfer and signaling     |
+   +------------------------------------------------+
+   |    Secure Transport Protocol (DTLS, ...)       |
+   +------------------------------------------------+
+   |    UDP for transport                           |
+   +------------------------------------------------+
+
+                    Figure 1: EST-coaps protocol layers
+
+   The EST-coaps protocol design follows closely the EST design,
+   excluding some aspects that are not relevant for automatic
+   bootstrapping of constrained devices within a professional context.
+   The parts supported by EST-coaps are:
+
+   Message types:
+
+      *  Simple enroll and reenroll.
+
+      *  CA certificate retrieval.
+
+      *  CSR Attributes request messages.
+
+      *  Server-side key generation messages.
+
+   The EST-coaps server URIs are identical to the EST URI (except for
+   replacing the scheme https by coaps):
+
+   coaps://www.example.com/.well-known/est
+   coaps://www.example.com/.well-known/est/arbitraryLabel1
+
+   Figure 5 in section 3.2.2 of [RFC7030] addresses he path URIs
+   (operations) are supported by EST.
+
+   The content-format (media type equivalent) of the CoAP message
+   determines which EST message is transported in the CoAP payload.  The
+   media types specified in the HTTP Content-Type header(see section
+   3.2.2 of [RFC7030]) are in EST-coaps specified by the Content-Format
+   Option (12) of CoAP.  The combination of URI path-suffix and content-
+   format used MUST map to an allowed combination of path-suffix and
+   media type as defined for EST.  The required content-formats for
+   these request and response messages are defined in Section 8.  The
+   CoAP response codes are defined in Section 4.2.
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 5]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   EST-coaps is designed for use between low-resource devices using CoAP
+   and hence does not need to send base64-encoded data.  Simple binary
+   coding is more efficient (30% less payload compared to base64) and
+   well supported by CoAP.  Therefore, the content formats specification
+   in Section 8 requires the use of binary encoding for all EST-coaps
+   CoAP payloads.  [EDNOTE: Revisit the binary format. ]
+
+4.1.  Message Bindings
+
+   This section describes BRSKI to CoAP message mappings.
+
+   CoAP defines confirmed (CON), acknowledgements (ACK), reset (RST) and
+   non-corfirmed (NON) message types.  For confirmable messages, the
+   responses are CoAP ACKs or RSTs.  All /cacerts, /simpleenroll,
+   /simplereenroll, /csrattrs and /serverkeygen EST messages expect a
+   response, so they are all COAP CON messages.
+
+   A CoAP message has the following fields ([RFC7252]):
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |Ver| T |  TKL  |      Code     |          Message ID           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Token (if any, TKL bytes) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Options (if any) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 1 1 1 1 1 1 1|    Payload (if any) ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Then Ver, TKL, Token, Message ID are not affected in BRSKI.  Their
+   use is the same as in CoAP.
+
+   The options that can be used in a CoAP header have the following
+   format:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 6]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+               0   1   2   3   4   5   6   7
+      +---------------+---------------+
+      |  Option Delta | Option Length |   1 byte
+      +---------------+---------------+
+      /         Option Delta          /   0-2 bytes
+      \          (extended)           \
+      +-------------------------------+
+      /         Option Length         /   0-2 bytes
+      \          (extended)           \
+      +-------------------------------+
+      \                               \
+      /         Option Value          /   0 or more bytes
+      \                               \
+      +-------------------------------+
+
+   Options are used to convey Uri-Host, Uri-Path, Uri-Port, Content-
+   Format and more in COAP.  For BRSKI, COAP Options are used to
+   communicate the HTTP fields used in the BRSKI REST messages.
+
+   BRSKI URLs are HTTPS based (https:// ), in CoAP these will be assumed
+   to be transformed to coaps (coaps://)
+
+   Some examples of how an BRSKI message would be translated in CoAP
+   follow.  [EDNOTE: This section to be expanded to ensure it covers all
+   BRSKI edge conditions.]  Appendix A includes some practical examples
+   of EST messages translated to COAP.  [EDNOTE: This section to be
+   expanded.
+
+4.2.  CoAP response codes
+
+   Section 5.9 of [RFC7252] specifies the mapping of HTTP response codes
+   to CoAP response codes.  Every time the HTTP response code 200 is
+   specified in [RFC7030] in response to a GET request, in EST-coaps the
+   equivalent CoAP response code 2.05 MUST be used.  Response code HTTP
+   202 in EST is mapped as indicated below; while other HTTP 2xx
+   response codes are not used by EST.  For the following HTTP 4xx error
+   codes that may occur: 400, 401, 403, 404, 405, 406, 412, 413, 415 ;
+   the equivalent CoAP response code for EST-coaps is 4.xx.  For the
+   HTTP 5xx error codes: 500, 501, 502, 503, 504 the equivalent CoAP
+   response code is 5.xx.
+
+   HTTP response code 202 needs a different treatment from the one
+   described for [RFC7030].  A new CoAP response code 2.06 is needed.
+   When the EST over CoAP request cannot be treated immediately, a CoAP
+   response code 2.06 Delayed is returned with Content-Format:
+   application/link-format described in [RFC6690].  The payload of the
+   response contains a link to receive the delayed response.
+   ALTERNATIVE (to discuss) : a 2.06 Delayed response without payload
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 7]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   and the link to receive the delayed response indicated using the
+   Location-Path and Location-Query Options.
+
+   The waiting client may send GET requests to the returned link.  When
+   the response is not available, the server returns response code 2.06
+   with again the link for the client to query.  When the response is
+   available, the server returns the response code 2.05 Content with a
+   payload containing the requested response in the appropriate content
+   format.
+
+   Appendix A includes some practical examples of HTTP response codes
+   from EST translated to COAP.
+
+4.3.  Message fragmentation
+
+   DTLS defines fragmentation only for the handshake part and not for
+   secure data exchange (DTLS records).  [RFC6347] states "Each DTLS
+   record MUST fit within a single datagram".  In order to avoid using
+   IP fragmentation, which is not supported by 6LoWPAN, invokers of the
+   DTLS record layer MUST size DTLS records so that they fit within any
+   Path MTU estimates obtained from the record layer.  In addition,
+   invokers residing on a 6LoWPAN over IEEE 802.15.4 network SHOULD
+   attempt to size CoAP messages such that each DTLS record will fit
+   within one or two IEEE 802.15.4 frames.
+
+   That is not always possible.  Even though ECC certificates are small
+   in size, they can vary greatly based on signature algorithms, key
+   sizes, and OID fields used.  For 256-bit curves, common ECDSA cert
+   sizes are 500-1000 bytes which could fluctuate further based on the
+   algorithms, OIDs, SANs and cert fields.  For 384-bit curves, ECDSA
+   certs increase in size and can sometimes reach 1.5KB.  Additionally,
+   there are times when the EST cacert response from the server can
+   include multiple certs that amount large payloads.  CoAP [RFC7252]'s
+   section 4.6 describes the possible payload sizes: "if nothing is
+   known about the size of the headers, good upper bounds are 1152 bytes
+   for the message size and 1024 bytes for the payload size".  Also "If
+   IPv4 support on unusual networks is a consideration, implementations
+   may want to limit themselves to more conservative IPv4 datagram sizes
+   such as 576 bytes; per [RFC0791], the absolute minimum value of the
+   IP MTU for IPv4 is as low as 68 bytes, which would leave only 40
+   bytes minus security overhead for a UDP payload".  Thus, even with
+   ECC certs, EST-coaps messages can still exceed sizes in MTU of 1280
+   for IPv6 or 60-80 bytes for 6LoWPAN [RFC4919] as explained in section
+   2 of [RFC7959].  EST-coaps needs to be able to fragment EST messages
+   into multiple DTLS datagrams with each DTLS datagram.  Fine-grained
+   fragmentation of EST messages is essential.
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 8]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   To perform fragmentation in COAP, [RFC7959] specifies the "Block1"
+   option for fragmentation of the request payload and the "Block2"
+   option for fragmentation of the return payload of a COAP flow.
+   Block1 options are used by the client PUT and POST requests.  A
+   Block1 in a client request requires a Block1 option in the responses.
+   A Block2 comes from a server response that will also need Block2 from
+   the client to acknowledge the block and get the rest of blocks from
+   the server.  Block1 is used when a request (POST for example) is used
+   with a payload that needs fragmentation.  The server responds with
+   Block1 option to acknowledge the fragment-blocks.  Block2 is used
+   when a BRSKI server response is big and needs fragmentation.  The
+   Block2 acknowledgements are requests with the same options as the
+   initial request and a Block2 option.  "To influence the block size
+   used in a response, the requester MAY also use the Block2 Option on
+   the initial request, giving the desired size, a block number of zero
+   and an M bit of zero".  The CoAP client MAY specify the Block1 size
+   and MAY also specify the Block2 size.  The CoAP server MAY specify
+   the Block2 size, but not the Block1 size.  As explained in Section 1
+   of [RFC7959]), blockwise transfers SHOULD be used in Confirmable COAP
+   messages to avoid the exacerbation of lost blocks.
+
+   In a scenario with a big BRSKI POST request we might have Block1
+   options from client to server and Block2 from server to client.  In
+   this case the Block1 blocks get completed and then the Block2 flows
+   the opposite direction.
+
+   The BLOCK draft also defines Size1 and Size2 options.  These are used
+   to convey the size of the resources in the requests or responses.
+   The Size1 response MAY be parsed by the client as an size indication
+   of the Block2 resource in the server response or by the server as a
+   request for a size estimate by the client.  Similarly, Size2 option
+   defined in BLOCK should be parsed by the server as an indication of
+   the size of the resource carried in Block1 options and by the client
+   as a maximum size expected in the 4.13 (Request Entity Too Large)
+   response to a request.
+
+   Block options in CoAP messages can contain fields, SZX, M and NUM
+   which are not affected by BRSKI.
+
+   Examples of fragmented messages are shown in Appendix B.
+
+5.  Transport Protocol
+
+   EST-coaps depends on a secure transport mechanism over UDP that can
+   secure (confidentiality, authenticity) the COAP messages exchanged.
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                 [Page 9]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+5.1.  DTLS
+
+   DTLS is one such secure protocol.  Within BRSKI and EST when "TLS" is
+   referred to, it is understood that in EST-coaps, security is provided
+   using DTLS instead.  No other changes are necessary (all provisional
+   modes etc are the same as for TLS).
+
+   COAP was designed to avoid fragmentation.  DTLS is used to secure
+   COAP messages.  When using DTLS, even though it can be avoided by
+   using pre-shared keys or ECC ciphersuites, sometimes fragmentation
+   will be needed.  During the DTLS handshake, if fragmentation is
+   necessary, "DTLS provides a mechanism for fragmenting a handshake
+   message over a number of records, each of which can be transmitted
+   separately, thus avoiding IP fragmentation" [RFC6347].
+
+   The EST-coaps client MUST be configured with an explicit TA database
+   at least an implicit TA database from its manufacturer.  The
+   authentication of the EST-coaps server by the EST-coaps client is
+   based on Certificate authentication in the DTLS handshake.
+
+   The authentication of the EST-coaps client is based on client
+   certificate in the DTLS handshake.  This can either be
+
+   o  DTLS with a previously issued client certificate (e.g., an
+      existing certificate issued by the EST CA);
+
+   o  DTLS with a previously installed certificate (e.g., manufacturer-
+      installed certificate or a certificate issued by some other
+      party);
+
+   The details on checking the validity of the certificates are
+   identical to EST.
+
+   EST-coaps does not support full PKI Requests.  Consequently, the
+   fullcmc request of section 4.3 of [RFC7030] and response MUST NOT be
+   supported by EST-coaps.
+
+   Channel-binding information for linking proof-of-identity with
+   message-based proof-of-possession (OPTIONAL).  Given that CoAP and
+   DTLS can provide proof of identity for EST-coaps clients and server,
+   simple PKI messages can be used conformant to section 3.1 of
+   [RFC5272].  EST-coaps supports the certificate types and Trust
+   Anchors (TA) that are specified for EST in section 3 of [RFC7030].
+   [EDNOTE: To describe POP in the DTLS context]
+
+   In a constrained CoAP environment, endpoints can't afford to
+   establish a DTLS connection for every EST transaction.
+   Authenticating and negotiating DTLS keys requires resources on low-
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 10]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   end endpoints and consumes valuable bandwidth.  The DTLS connection
+   SHOULD remain open for persistent EST connections.  For example, an
+   EST cacerts request that is followed by a simpleenroll request can
+   use the same authenticated DTLS connection.  Given that after a
+   successful enrollment, it is more likely that a new EST transaction
+   will take place after a significant amount of time, the DTLS
+   connections SHOULD only be kept alive for EST messages that are
+   relatively close to each other.
+
+   The mandatory cipher suite for DTLS is
+   TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 defined in [RFC7251] which is the
+   mandatory-to-implement cipher suite in CoAP.  Additionally the curve
+   secp256r1 MUST be supported [RFC4492]; this curve is equivalent to
+   the NIST P-256 curve.  The hash algorithm is SHA-256.  DTLS
+   implementations MUST use the Supported Elliptic Curves and Supported
+   Point Formats Extensions [RFC4492]; the uncompressed point format
+   MUST be supported; [RFC6090] can be used as an implementation method.
+
+5.2.  [EDNOTE: Placeholder]
+
+   [EDNOTE: Other secure transport mechanisms placeholder section. ]
+
+6.  Proxying
+
+   [EDNOTE: This section to be populated.  It will address how proxying
+   can take place by an entity that resides at the edge of the CoAP
+   network, such as the Registrar, and can reach the BRSKI server
+   residing in a traditional "TCP setting". ]
+
+7.  Parameters
+
+   [EDNOTE: This section to be populated.  It will address transmission
+   parameters for BRSKI described in sections 4.7 and 4.8 of the CoAP
+   draft.  BRSKI does not impose any unique parameters that affect the
+   CoAP parameters in Table 2 and 3 in the CoAP draft but the ones in
+   CoAP could be affecting BRSKI.  For example the processing delay of
+   CAs could be less then 2s, but in this case they should send an CoAP
+   ACK every 2s while processing.]
+
+8.  IANA Considerations
+
+   Additions to the sub-registry "CoAPContent-Formats", within the "CoRE
+   Parameters" registry are needed for the below media types.  These can
+   be registered either in the Expert Review range (0-255) or IETF
+   Review range (256-9999).
+
+   1.
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 11]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+       *  application/pkcs7-mime
+
+       *  Type name: application
+
+       *  Subtype name: pkcs7-mime
+
+       *  smime-type: certs-only
+
+       *  ID: TBD1
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [RFC5751]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   2.
+
+       *  application/pkcs8
+
+       *  Type name: application
+
+       *  Subtype name: pkcs8
+
+       *  ID: TBD2
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [RFC5958]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   3.
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 12]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+       *  application/csrattrs
+
+       *  Type name: application
+
+       *  Subtype name: csrattrs
+
+       *  ID: TBD3
+
+       *  Required parameters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: Binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [RFC7030]
+
+       *  Applications that use this media type: ANIMA Bootstrap (BRSKI)
+          and EST
+
+   4.
+
+       *  application/pkcs10
+
+       *  Type name: application
+
+       *  Subtype name: pkcs10
+
+       *  ID: TBD4
+
+       *  Required paraeters: None
+
+       *  Optional parameters: None
+
+       *  Encoding considerations: binary
+
+       *  Security considerations: As defined in this specification
+
+       *  Published specification: [RFC5967]
+
+       *  Applications that use this media type: ANIMA bootstrap (BRSKI)
+          and EST
+
+   Additions to the sub-registry "CoAP Response Code", within the "CoRE
+   Parameters" registry are needed for the following response codes:
+
+   o  Code: 2.06
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 13]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   o  Description: Delayed
+
+   o  Reference: this document
+
+   [EDNOTE: This section will be expanded to includes types needed that
+   do not exist in COAP.]
+
+9.  Security Considerations
+
+   [EDNOTE: This section to be populated.  This document describes an
+   existing protocol moved to CoAP and there should not be additional
+   security concerns added beyond the protocol's or CoAP's specifics
+   security considerations.  The security considerations mentioned in
+   EST applies also to EST-coaps.  Specifically for server-side key
+   generation, it introduces implications for the endpoints and their
+   private keys, which will be covered here. ]
+
+10.  Acknowledgements
+
+   The authors are very grateful to Klaus Hartke for his detailed
+   explanations on the use of Block with DTLS.  The authors would like
+   to thank Esko Dijk and Michael Verschoor for the valuable discussions
+   that helped in shaping the solution.  They would also like to thank
+   Peter Panburana from Cisco for his feedback on technical details of
+   the solution.
+
+11.  Change Log
+
+   -01:
+
+      Merging of draft-vanderstok-ace-coap-est-00 and draft-vanderstok-
+      ace-coap-est-01
+
+12.  References
+
+12.1.  Normative References
+
+   [I-D.ietf-anima-bootstrapping-keyinfra]
+              Pritikin, M., Richardson, M., Behringer, M., Bjarnason,
+              S., and K. Watsen, "Bootstrapping Remote Secure Key
+              Infrastructures (BRSKI)", draft-ietf-anima-bootstrapping-
+              keyinfra-04 (work in progress), October 2016.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 14]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   [RFC5272]  Schaad, J. and M. Myers, "Certificate Management over CMS
+              (CMC)", RFC 5272, DOI 10.17487/RFC5272, June 2008,
+              <http://www.rfc-editor.org/info/rfc5272>.
+
+   [RFC5751]  Ramsdell, B. and S. Turner, "Secure/Multipurpose Internet
+              Mail Extensions (S/MIME) Version 3.2 Message
+              Specification", RFC 5751, DOI 10.17487/RFC5751, January
+              2010, <http://www.rfc-editor.org/info/rfc5751>.
+
+   [RFC5967]  Turner, S., "The application/pkcs10 Media Type", RFC 5967,
+              DOI 10.17487/RFC5967, August 2010,
+              <http://www.rfc-editor.org/info/rfc5967>.
+
+   [RFC6347]  Rescorla, E. and N. Modadugu, "Datagram Transport Layer
+              Security Version 1.2", RFC 6347, DOI 10.17487/RFC6347,
+              January 2012, <http://www.rfc-editor.org/info/rfc6347>.
+
+   [RFC6690]  Shelby, Z., "Constrained RESTful Environments (CoRE) Link
+              Format", RFC 6690, DOI 10.17487/RFC6690, August 2012,
+              <http://www.rfc-editor.org/info/rfc6690>.
+
+   [RFC7030]  Pritikin, M., Ed., Yee, P., Ed., and D. Harkins, Ed.,
+              "Enrollment over Secure Transport", RFC 7030,
+              DOI 10.17487/RFC7030, October 2013,
+              <http://www.rfc-editor.org/info/rfc7030>.
+
+   [RFC7252]  Shelby, Z., Hartke, K., and C. Bormann, "The Constrained
+              Application Protocol (CoAP)", RFC 7252,
+              DOI 10.17487/RFC7252, June 2014,
+              <http://www.rfc-editor.org/info/rfc7252>.
+
+   [RFC7959]  Bormann, C. and Z. Shelby, Ed., "Block-Wise Transfers in
+              the Constrained Application Protocol (CoAP)", RFC 7959,
+              DOI 10.17487/RFC7959, August 2016,
+              <http://www.rfc-editor.org/info/rfc7959>.
+
+12.2.  Informative References
+
+   [ieee802.15.4]
+              Institute of Electrical and Electronics Engineers, , "IEEE
+              Standard 802.15.4-2006", 2006.
+
+   [RFC4492]  Blake-Wilson, S., Bolyard, N., Gupta, V., Hawk, C., and B.
+              Moeller, "Elliptic Curve Cryptography (ECC) Cipher Suites
+              for Transport Layer Security (TLS)", RFC 4492,
+              DOI 10.17487/RFC4492, May 2006,
+              <http://www.rfc-editor.org/info/rfc4492>.
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 15]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   [RFC4919]  Kushalnagar, N., Montenegro, G., and C. Schumacher, "IPv6
+              over Low-Power Wireless Personal Area Networks (6LoWPANs):
+              Overview, Assumptions, Problem Statement, and Goals",
+              RFC 4919, DOI 10.17487/RFC4919, August 2007,
+              <http://www.rfc-editor.org/info/rfc4919>.
+
+   [RFC4944]  Montenegro, G., Kushalnagar, N., Hui, J., and D. Culler,
+              "Transmission of IPv6 Packets over IEEE 802.15.4
+              Networks", RFC 4944, DOI 10.17487/RFC4944, September 2007,
+              <http://www.rfc-editor.org/info/rfc4944>.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246,
+              DOI 10.17487/RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
+
+   [RFC5958]  Turner, S., "Asymmetric Key Packages", RFC 5958,
+              DOI 10.17487/RFC5958, August 2010,
+              <http://www.rfc-editor.org/info/rfc5958>.
+
+   [RFC6090]  McGrew, D., Igoe, K., and M. Salter, "Fundamental Elliptic
+              Curve Cryptography Algorithms", RFC 6090,
+              DOI 10.17487/RFC6090, February 2011,
+              <http://www.rfc-editor.org/info/rfc6090>.
+
+   [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Message Syntax and Routing",
+              RFC 7230, DOI 10.17487/RFC7230, June 2014,
+              <http://www.rfc-editor.org/info/rfc7230>.
+
+   [RFC7251]  McGrew, D., Bailey, D., Campagna, M., and R. Dugal, "AES-
+              CCM Elliptic Curve Cryptography (ECC) Cipher Suites for
+              TLS", RFC 7251, DOI 10.17487/RFC7251, June 2014,
+              <http://www.rfc-editor.org/info/rfc7251>.
+
+   [RFC7641]  Hartke, K., "Observing Resources in the Constrained
+              Application Protocol (CoAP)", RFC 7641,
+              DOI 10.17487/RFC7641, September 2015,
+              <http://www.rfc-editor.org/info/rfc7641>.
+
+Appendix A.  EST messages to EST-coaps
+
+A.1.  cacerts
+
+   In EST, an HTTPS cacerts message can be
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 16]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+     GET /.well-known/est/cacerts HTTP/1.1
+        User-Agent: curl/7.22.0 (i686-pc-linux-gnu) libcurl/7.22.0
+                    OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
+        Host: 192.0.2.1:8085
+        Accept: */*
+
+   The corresponding CoAP request is
+
+   REQ:
+           GET coaps://[192.0.2.1:8085]/.well-known/est/cacerts
+
+   with COAP fields
+
+     Ver = 1
+     T = 0 (CON)
+     Code = 0x01 (0.01 is GET)
+     Options
+      Option1 (Uri-Host)
+        Option Delta = 0x3
+        Option Length = 0x9
+        Option Value = 192.0.2.1
+      Option2 (Uri-Port)
+        Option Delta = 0xA
+        Option Length = 0x4
+        Option Value = 8085
+      Option3 (Uri-Path)
+        Option Delta = 0xD
+        Option Length = 0xD
+        Extended Option Delta = 0x08
+        Extended Option Length = 0x14
+        Option Value = /.well-known/est/cacerts HTTP/1.1
+     Payload = [Empty]
+
+   A 200 OK response with a cert in EST will them be
+
+      HTTP/1.1 200 OK
+      Status: 200 OK
+      Content-Type: application/pkcs7-mime
+      Content-Transfer-Encoding: base64 [EDNOTE: Verify if we need a new
+                                         option registry for Encoding?)
+      Content-Length: 4246 [EDNOTE: this example overflows and would
+                            need fragmentation. Choose a better example.
+                            Regardless we might need an CoAP option for
+                            the content-length ie the CoAP payload?)
+
+      MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExADALBgkqhkiG9w0BBwGgggwMMIIC
+      +zCCAeOgAwIBAgIJAJpY3nUZO3qcMA0GCSqGSIb3DQEBBQUAMBsxGTAXBgNVBAMT
+      ...
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 17]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   The corresponding CoAP response is
+
+   RES:
+           2.05 Content (Content-Format: application/pkcs7-mime)
+           {payload}
+
+   with COAP fields
+
+    Ver = 1
+    T = 2 (ACK)
+    Code = 0x21 [EDNOTE: Maybe we need to create a 0x200 response code.)
+    Options
+      Option1 (Content-Format)
+        Option Delta = 0xC
+        Option Length = 0xD
+        Extended Option Length = 0x09
+        Option Value = <number for application/pkcs7-mime>
+                  [EDNOTE: We need a new CoAP IANA registered value
+                  application/pkcs7-mime; smime-type=certs-only,
+                  application/csrattrs, application/pkcs10,
+                  application/pkcs8,
+                  application/pkcs12 )
+    Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExA \
+                DALBgkqhkiG9w0BBwGgggwMMIIC...
+
+A.2.  enroll / reenroll
+
+   [EDNOTE: username/password authentication can be described here but
+   is not a primary focus for BRSKI.  It is important for generic EST
+   exchanges but would an endpoint device with sufficient user interface
+   to allow username/password input from an end user be required to use
+   CoAP instead of a full HTTPS exchange?]
+
+   [EDNOTE: We might need a new Option for the Retry-After response
+   message.  We might need a new Option for the WWW-Authenticate
+   response.]
+
+   [EDNOTE: Include COAP message examples. ]
+
+A.3.  csrattr
+
+   [EDNOTE: Include COAP message examples. ]
+
+A.4.  enrollstatus
+
+   [EDNOTE: Include COAP message examples. ]
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 18]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+A.5.  voucher_status
+
+   [EDNOTE: Include COAP message examples. ]
+
+A.6.  requestvoucher
+
+   [EDNOTE: Include COAP message examples. ]
+
+A.7.  requestlog
+
+   [EDNOTE: Include COAP message examples. ]
+
+   [EDNOTE: More examples can be added, for server-side key generation
+   in CMS envelopes. ]
+
+Appendix B.  EST-coaps Block message examples
+
+   This section provides detailed examples of the messages using DTLS
+   and BLOCK option Block2.  The minimum PMTU is 1280 bytes, which is
+   the example value assumed for the DTLS datagram size.  The example
+   block length is taken as 64 which gives an SZX value of 2.
+
+   The following is an example of a valid /cacerts exchange over DTLS. .
+   The content length of the cacerts response in appendix A.1 of
+   [RFC7030] is 4246 bytes using base64.  This leads to a length of 3185
+   bytes in binary.  The CoAP message adds around 10 bytes, the DTLS
+   record 29 bytes.  To avoid IP fragmentation, the CoAP block option is
+   used and an MTU of 127 is assumed to stay within one IEEE 802.15.4
+   packet.  To stay below the MTU of 127, the payload is split in 50
+   packets with a payload of 64 bytes each.  The client sends an IPv6
+   packet containing the UDP datagram with the DTLS record that
+   encapsulates the CoAP Request 50 times.  The server returns an IPv6
+   packet containing the UDP datagram with the DTLS record that
+   encapsulates the CoAP response.  The CoAP request-response exchange
+   with block option is shown below.  Block option is shown in a
+   decomposed way indicating the kind of Block option (2 in this case
+   because used in the response) followed by a colon, and then the block
+   number (NUM), the more bit (M = 0 means last block), and block size
+   exponent (2**(SZX+4)) separated by slashes.  The Length 64 is used
+   with SZX= 2 to avoid IP fragmentation.  The CoAP Request is sent with
+   confirmable (CON) option and the content format of the Response is
+   /application/cacerts.
+
+
+
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 19]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+   GET [192.0.2.1:8085]/.well-known/est/cacerts     -->
+                 <--   (2:0/1/64) 2.05 Content
+       GET URI (2:1/1/64)                           -->
+                 <--   (2:1/1/64) 2.05 Content
+                         |
+                         |
+                         |
+        GET URI (2:49/1/64)                         -->
+                 <--   (2:49/0/64) 2.05 Content
+
+   An example HTTP cacerts response that exceeds the MTU can be
+
+   HTTP/1.1 200 OK
+      Status: 200 OK
+      Content-Type: application/pkcs7-mime; smime-type=certs-only
+      Content-Transfer-Encoding: base64
+      Content-Length: 1122
+
+      MIIDOAYJKoZIhvcNAQcCoIIDKTCCAyUCAQExADALBgkqhkiG9w0BBwGgggMLMIID
+      BzCCAe+gAwIBAgIBFTANBgkqhkiG9w0BAQUFADAbMRkwFwYDVQQDExBlc3RFeGFt
+      cGxlQ0EgTndOMB4XDTEzMDUwOTIzMTU1M1oXDTE0MDUwOTIzMTU1M1owHzEdMBsG
+      A1UEAxMUZGVtb3N0ZXA0IDEzNjgxNDEzNTIwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+      DwAwggEKAoIBAQClNp+kdz+Nj8XpEp9kaumWxDZ3eFYJpQKz9ddD5e5OzUeCm103
+      ZIXQIxc0eVtMCatnRr3dnZRCAxGjwbqoB3eKt29/XSQffVv+odbyw0WdkQOIbntC
+      Qry8YdcBZ+8LjI/N7M2krmjmoSLmLwU2V4aNKf0YMLR5Krmah3Ik31jmYCSvwTnv
+      6mx6pr2pTJ82JavhTEIIt/fAYq1RYhkM1CXoBL+yhEoDanN7TzC94skfS3VV+f53
+      J9SkUxTYcy1Rw0k3VXfxWwy+cSKEPREl7I6k0YeKtDEVAgBIEYM/L1S69RXTLuji
+      rwnqSRjOquzkAkD31BE961KZCxeYGrhxaR4PAgMBAAGjUjBQMA4GA1UdDwEB/wQE
+      AwIEsDAdBgNVHQ4EFgQU/qDdB6ii6icQ8wGMXvy1jfE4xtUwHwYDVR0jBBgwFoAU
+      scRp5lujBKfYl6OLO7+5arIyQjwwDQYJKoZIhvcNAQEFBQADggEBACmxg1hvL6+7
+      a+lFTARoxainBx5gxdZ9omSb0L+qL+4PDvg/+KHzKsDnMCrcU6M4YP5n0EDKmGa6
+      4lY8fbET4tt7juJg6ixb95/760Th0vuctwkGr6+D6ETTfqyHnrbhX3lAhnB+0Ja7
+      o1gv4CWxh1I8aRaTXdpOHORvN0SMXdcrlCys2vrtOl+LjR2a3kajJO6eQ5leOdzF
+      QlZfOPhaLWen0e2BLNJI0vsC2Fa+2LMCnfC38XfGALa5A8e7fNHXWZBjXZLBCza3
+      rEs9Mlh2CjA/ocSC/WxmMvd+Eqnt/FpggRy+F8IZSRvBaRUCtGE1lgDmu6AFUxce
+      R4POrT2xz8ChADEA
+
+   As another example, let's assume that the cacerts message will need
+   to be broken up to three messages.  The first Block2 will be
+
+
+
+
+
+
+
+
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 20]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+     Ver = 1
+     T = 2 (ACK)
+     Code = 0x21 (2.01 success message.
+            EDNOTE: Do we need to create a 0x200 respond code.)
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = <number for application/pkcs7-mime;
+                         smime-type=certs-only>
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x0D
+     Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYC \
+               AQExADALBgkqhkiG9w0BBwGgggwMMIIC... (512 bytes)
+   [EDNOTE: Potentially replace base64 with binary ]
+
+   The second Block2:
+
+     Ver = 1
+     T = 2 (means ACK)
+     Code = 0x21
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = <number for application/pkcs7-mime;
+                        smime-type=certs-only>
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12 ]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x1D
+     Payload = ... (512 bytes)
+
+   The third and final Block2:
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 21]
+
+Internet-Draft                  EST-coaps                   January 2017
+
+
+     Ver = 1
+     T = 2 (means ACK)
+     Code = 0x21
+     Options
+       Option1 (Content-Format)
+         Option Delta = 0xC
+         Option Length = 0xD
+         Extended Option Length = 0x09
+         Option Value = <number for application/pkcs7-mime;
+                         smime-type=certs-only>
+                   [EDNOTE: We need a new CoAP IANA registered value
+                   application/pkcs7-mime, application/csrattrs,
+                   application/pkcs10, application/pkcs8,
+                   application/pkcs12 ]
+       Option2 (Block2)
+         Option Delta = 0xD
+         Option Length = 0x1
+         Extended Option Delta = 0x16
+         Option Value = 0x25
+     Payload = ...
+
+   [EDNOTE: We can add Fragmented request example with Block1 ]
+
+   [EDNOTE: Fragmented request/response example with Block1, Size1 and
+   Block2">
+
+Authors' Addresses
+
+   Sandeep S. Kumar
+   Philips Lighting Research
+   High Tech Campus 7
+   Eindhoven  5656 AE
+   NL
+
+   Email: ietf@sandeep.de
+
+
+   Peter van der Stok
+   Consultant
+
+   Email: consultancy@vanderstok.org
+
+
+   Panos Kampanakis
+   Cisco Systems
+
+   Email: pkampana@cisco.com
+
+
+
+
+Kumar, et al.             Expires July 22, 2017                [Page 22]

--- a/draft-vanderstok-ace-coap-est.xml
+++ b/draft-vanderstok-ace-coap-est.xml
@@ -13,15 +13,16 @@
 <!ENTITY RFC6090 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6090.xml">
 <!ENTITY RFC6347 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6347.xml">
 <!ENTITY RFC6690 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6690.xml">
-<!ENTITY RFC6838 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6838.xml">
+<!-- <!ENTITY RFC6838 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6838.xml"> -->
 <!ENTITY RFC7030 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7030.xml">
 <!ENTITY RFC7230 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7230.xml">
 <!ENTITY RFC7251 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7251.xml">
 <!ENTITY RFC7252 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7252.xml">
 <!ENTITY RFC7959 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7959.xml">
+<!ENTITY RFC7641 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7641.xml">
+<!ENTITY RFC4919 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4919.xml">
 <!ENTITY I-D.ietf-anima-bootstrapping-keyinfra SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-anima-bootstrapping-keyinfra.xml">
 ]>
-
 
 <?rfc strict="no" ?>
 <?rfc toc="yes"?>
@@ -33,7 +34,7 @@
 
 <rfc category="std" ipr="trust200902" docName="draft-vanderstok-ace-coap-est-00">
   <front>
-    <title abbrev="EST-coaps">EST based on DTLS secured CoAP (EST-coaps)</title>
+    <title abbrev="EST-coaps">EST over secure CoAP (EST-coaps)</title>
     
     <author initials="S.S." surname="Kumar" fullname="Sandeep S. Kumar">
       <organization>Philips Lighting Research</organization>
@@ -48,433 +49,434 @@
         <email>ietf@sandeep.de</email>
       </address>
     </author>
-    
-  
-     <author fullname="Peter van der Stok" initials="P." surname="van der Stok">
+    <author fullname="Peter van der Stok" initials="P." surname="van der Stok">
       <organization>Consultant</organization>
-
       <address>
         <email>consultancy@vanderstok.org</email>
       </address>
     </author>
-        
+    <author fullname="Panos Kampanakis" initials="P" surname="Kampanakis">
+      <organization>Cisco Systems</organization>
+      <address>
+        <email>pkampana@cisco.com</email>
+      </address>
+    </author>
     <date/>
     <area>Security</area>
-    <workgroup>ace</workgroup>
+    <workgroup>ACE</workgroup>
+
     <abstract>
-      <t>
-    Low-resource devices in a Low-power and Lossy Network (LLN) can operate in a mesh network using the IPv6 over Low-power Personal Area Networks (6LoWPAN) and IEEE 802.15.4 link-layer standards. Provisioning these devices in a secure manner with keys (often called security bootstrapping) used to encrypt and authenticate messages is the subject of Bootstrapping of Remote Secure Key Infrastructures (BRSKI) <xref target="I-D.ietf-anima-bootstrapping-keyinfra"/>. Enrollment over Secure Transport (EST) <xref target="RFC7030"/>, based on TLS and HTTP, is used for BRSKI. This document defines how low-resource devices are expected to use EST over DTLS and CoAP. 6LoWPAN fragmentation management and minor extensions to CoAP are needed to enable EST over DTLS-secured CoAP (EST-coaps).
-      </t>
+      <t>Low-resource devices in a Low-power and Lossy Network (LLN) can operate in a mesh network using the IPv6 over Low-power Personal Area Networks (6LoWPAN) and IEEE 802.15.4 link-layer standards. Provisioning these devices in a secure manner with keys (often called security bootstrapping) used to encrypt and authenticate messages is the subject of Bootstrapping of Remote Secure Key Infrastructures (BRSKI) <xref target="I-D.ietf-anima-bootstrapping-keyinfra"/>. Enrollment over Secure Transport (EST) <xref target="RFC7030"/>, based on TLS and HTTP, is used in BRSKI. Low-resource devices often use the lightweight Constrained Application Protocol (COAP) <xref target="RFC7252"/> for message exchanges. This document defines how low-resource devices are expected to use EST over secure CoAP (EST-coaps) for secure bootstrapping and certificate enrollment. 6LoWPAN fragmentation management and minor extensions to CoAP are needed to enable EST-coaps.</t>
     </abstract>
-<note title="Note">
-      <t>
-        Many of the concepts in this document are taken over from <xref target="RFC7030"/>. Consequently, much text is directly traceable to <xref target="RFC7030"/>. The same document structure is followed to point out the differences and commonalities between EST and EST-coaps.
-      </t>
-    </note>
 
+    <!-- <note title="Note">
+      <t>Many of the concepts in this document are taken over from <xref target="RFC7030"/>. Consequently, much text is directly traceable to <xref target="RFC7030"/>. The same document structure is followed to point out the differences and commonalities between EST and EST-coaps.</t>
+    </note> -->
   </front>
-  
-  
+
+
 <middle>
+  <section anchor="intro" title="Introduction">
+    <t>IPv6 over Low-power Wireless Personal Area Networks (6LoWPANs) <xref target="RFC4944" /> on IEEE 802.15.4 <xref target="ieee802.15.4" /> wireless networks is becoming common in many industry application domains such as lighting controls. However commissioning of such networks suffers from a lack of standardized secure bootstrapping mechanisms for these networks.</t>
+    <t>Although IEEE 802.15.4 defines how security can be enabled between nodes within a single mesh network, it does not specify the provisioning and management of the keys. Therefore securing a 6LoWPAN network with devices from multiple manufacturers with different provisioning techniques is often tedious and time consuming.</t>
+    <t>Bootstrapping of Remote Secure Infrastructures (BRSKI) <xref target="I-D.ietf-anima-bootstrapping-keyinfra"/> addresses the issue of bootstrapping networked devices in the context of Autonomic Networking Integrated Model and Approach (ANIMA). However, BRSKI has not been developed specifically for low-resource devices in constrained networks. These networks use DTLS <xref target="RFC6347"/>, CoAP <xref target="RFC7252"/>, and UDP instead of TLS <xref target="RFC5246"/>, HTTP <xref target="RFC7230"/> and TCP. BRSKI relies on HTTP RESTful APIs and enrollment over Secure Transport (EST) <xref target="RFC7030"/> for the provisioning of the operational domain certificates. Replacing the EST invocations of TLS and HTTP by UDP and CoAP invocations enables applying BRSKI on CoAP-based low-resource devices.</t>
+    <t>Although EST-coaps paves the way for the utilization of BRSKI and EST for constrained devices on constrained networks, some devices will not have enough resources to handle the large payloads that come with EST-coaps. The definition of EST-coaps is intended to ensure that bootstrapping works for less constrained devices that choose to limit their communications stack to UDP/CoAP. It is up to the network designer to decide which devices execute the EST protocol and which not.</t>
+    <t>EST-coaps is designed for use in professional control networks such as lighting. The autonomic bootstrapping is interesting because it reduces the manual intervention during the commissioning of the network. Typing in passwords is contrary to this wish. Therefore, the HTTP Basic authentication of EST is not supported in EST-coaps. </t>
+    <t>In the constrained devices context it is very unlikely that full PKI request messages will be used. For that reason, full PKI messages are not supported in EST-coaps.</t>
+    <t>Because the relatively large messages involved in EST cannot be readily transported over constrained (6LoWPAN, LLN) wireless networks, this document defines the use of CoAP Block-Wise Transfer ("Block") <xref target="RFC7959"/> to fragment EST messages at the application layer.</t>
+    <t>Support for Observe CoAP options <xref target="RFC7641"/> in Blocks with BRSKI is not supported in the current BRSKI/EST message flows and is thus out-of-scope for this discussion. Observe options could be used by the server to notify clients about a change in the cacerts or csr attributes (resources) and might be an area of future work.</t>
+  </section>  <!-- Introduction -->
 
-<section anchor="intro" title="Introduction">
 
-<t>
-IPv6 over Low-power Wireless Personal Area Networks (6LoWPANs) <xref target="RFC4944" /> on IEEE 802.15.4 <xref target="ieee802.15.4" /> wireless networks is becoming common in many professional application domains such as lighting controls. However commissioning of such networks suffers from a lack of standardized  secure bootstrapping mechanisms for these networks.</t>
-<t>Although IEEE 802.15.4 defines how security can be enabled between nodes within a single mesh network, it does not specify the provisioning and management of the keys. Therefore securing a 6LoWPAN network with devices from multiple manufacturers with different provisioning techniques is often tedious and time consuming.
-</t><t>
-Bootstrapping of Remote Secure Infrastructures (BRSKI) <xref target="I-D.ietf-anima-bootstrapping-keyinfra"/> addresses the issue of bootstrapping networked devices in the context of Autonomic Networking Integrated Model and Approach (ANIMA). However, BRSKI has not been developed specifically for low-resource devices in constrained networks. These networks use DTLS <xref target="RFC6347"/>, CoAP <xref target="RFC7252"/>, and UDP instead of TLS <xref target="RFC5246"/>, HTTP <xref target="RFC7230"/> and TCP. BRSKI relies on
-   Enrollment over Secure Transport (EST) <xref target="RFC7030"/> for the provisioning of the operational domain certificates. Replacing the EST invocations of TLS and HTTP by DTLS and CoAP invocations enables applying BRSKI on CoAP-based low-resource devices.
-</t><t>
-The <xref target="fig-est-coaps-layers"/> below shows the EST-coaps architecture.
-</t>
+  <section title="Terminology">
+    <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <xref target="RFC2119"/>. </t>
+    <t>All the terminology from EST <xref target="RFC7030"/> is included in this document by reference.</t>
+  </section>   <!-- Terminology -->
+
+
+  <section anchor="scenario" title="EST/BRSKI operational differences">
+    <t>Only the differences to EST and BRSKI with respect to operational scenarios are described in this section. EST-coaps server authentication differs from EST as follows:
+      <list style="symbols">
+        <t>Replacement of TLS by a secure transport protocol and HTTP by CoAP, resulting in:
+        <list>
+          <t>DTLS-secured CoAP sessions between EST-coaps client and EST-coaps server.</t>
+        </list></t>
+        <t> Only certificate-based client authentication is supported, which results in:
+          <list>
+            <t>The EST-coaps client does not support HTTP Basic authentication (as described in Section 4.4.1 of <xref target="RFC7030"/>) </t>
+            <!-- <t>The EST-coaps client does not support authentication at the application layer.</t> --> <!-- Panos: Not sure what this meant. -->
+          </list></t>
+        <t>EST-coaps does not support full PKI request messages<xref target="RFC5272"/>.</t>
+      </list></t>
+  </section>  <!-- Operational scenario overview -->
+
+
+  <section anchor="design" title="Protocol Design and Layering">
+    <t>EST-coaps uses CoAP to transfer EST messages, aided by Block-Wise Transfer <xref target="RFC7959"/> to transport CoAP messages in blocks thus avoiding (excessive) 6LoWPAN fragmentation of UDP datagrams. The use of "Block" for the transfer of larger EST messages is specified in <xref target="fragment"/>. The <xref target="fig-est-coaps-layers"/> below shows the layered EST-coaps architecture.</t>
 <figure align="left" title="EST-coaps protocol layers" anchor="fig-est-coaps-layers"><artwork><![CDATA[
-+---------------------------------------------------------+
-|                                                         |
-|    EST request/response messages                        |
-|                                                         |
-+---------------------------------------------------------+
-|                                                         |
-|    CoAP for message transfer and signaling              |
-|                                                         |
-+---------------------------------------------------------+
-|                                                         |
-|    DTLS for transport security                          |
-|                                                         |
-+---------------------------------------------------------+
-|                                                         |
-|    UDP for transport                                    |
-|                                                         |
-+---------------------------------------------------------+
-
++------------------------------------------------+
+|    EST request/response messages               |
++------------------------------------------------+
+|    CoAP for message transfer and signaling     |
++------------------------------------------------+
+|    Secure Transport Protocol (DTLS, ...)       |
++------------------------------------------------+
+|    UDP for transport                           |
++------------------------------------------------+
 ]]></artwork></figure>
-
-<t>
-Although EST-coaps paves the way for the utilization of BRSKI for constrained devices on constrained networks, some devices will not have enough resources to handle the large payloads that come with EST-coaps. It is up to the network designer to decide which devices execute the BRSKI protocol and which not.
-</t><t>
-EST-coaps is designed for use in professional control networks such as lighting. The autonomic bootstrapping is interesting because it reduces the manual intervention during the commissioning of the network. Typing in passwords is contrary to this wish. Therefore, the password authentication of EST is not supported in EST-coaps. 
-</t><t>In the constrained devices context it is very unlikely that full PKI request messages will be used. For that reason, full PKI messages are not supported in EST-coaps.
-</t><t>
-Because the relatively large messages involved in EST cannot be readily transported over constrained (6LoWPAN, LLN) wireless networks, this document defines the use of CoAP Block-Wise Transfer ("Block") <xref target="RFC7959"/> combined with DTLS to fragment EST messages at the application layer.
-</t>
-
-<section title="Terminology">
-            <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
-            "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
-            and "OPTIONAL" in this document are to be interpreted as
-            described in <xref target="RFC2119"/>.	    
-</t>
-<t>All the terminology from EST <xref target="RFC7030"/> is included in this document by reference.</t>
-
-</section>   <!-- Terminology -->
-
-</section>  <!-- Introduction -->
-
-
-<section anchor="scenario" title="Operational Scenarios Overview">
-<t>
-Only the differences to EST with respect to operational scenarios are described in this section. EST-coaps server authentication differs from EST as follows:
-<list style="symbols">
-<t> Replacement of TLS by DTLS and HTTP by CoAP, resulting in:
-<list>
-<t>DTLS-secured CoAP sessions between EST-coaps client and EST-coaps server.</t>
-</list> </t>
-<t> Only certificate-based client authentication is supported, with as result:
-<list>
-<t> The EST-coaps client does not support manual authentication (as described in Section 4.4.1 of <xref target="RFC7030"/>) </t>
-<t> The EST-coaps client does not support authentication at the application layer.</t>
-</list></t>
-<t> EST-coaps does not support full PKI request messages
-       <xref target="RFC5272"/>.
-</t>
-</list>
-The following EST-coaps protocol parts are supported as described for the equivalent EST parts:
-<list style ="numbers">
-<t>Request of client certificates by submitting a enrollment request to EST-coaps server. </t>
-<t>Renewal of existing client certificates by submitting a re-enrollment request to EST-coaps server. </t>
-<t>Request of certificate with key pair generated by EST-coaps server.</t>
-<t> The EST-coaps client can request the attributes needed for enrollment before the enrollment request is issued"</t>
-</list>
-
-</t>
-</section>  <!-- Operational scenario overview -->
-
-<section anchor="design" title="Protocol Design and Layering">
-<t>
-The EST-coaps protocol design follows closely the EST design, excluding some aspects that are not relevant for automatic bootstrapping of constrained devices within a professional context. The parts supported by EST-coaps are:
-<list style="hanging">
-<t hangText="Message types:">
-<list style="symbols">
-<t>Simple PKI messages.</t>
-<t>CA certificate retrieval.</t>
-<t>CSR Attributes Request.</t>
-<t>Server-generated key request. </t>
-</list>
-</t>
-<t hangText="CoAP with Block-Wise Transfer:">
-<list style="symbols">
-<t> CoAP Block-Wise Transfer header Options for control of the transfer of larger EST messages.</t>
-</list>
-</t>
-<t hangText="DTLS for transport security:">
-<list style="symbols">
-<t> Authentication of the EST-coaps server. </t>
-<t> Authentication of the EST-coaps client. </t>
-<t> Communication integrity and confidentiality.</t>
-<t> Channel-binding information for linking proof-of-identity with message-based proof-of-possession (OPTIONAL).
-</t>
-</list>
-</t>
-</list>
-Given that CoAP and DTLS can provide proof of identity for EST-coaps clients and server, simple PKI messages can be used conformant to section 3.1 of <xref target="RFC5272"/>. EST-coaps supports the certificate types and Trust Anchors (TA) that are specified for EST in section 3 of <xref target="RFC7030"/>.
-</t><t>
-The EST-coaps server URI is identical to the EST URI (except for replacing the scheme https by coaps): 
-</t>
+    <t>The EST-coaps protocol design follows closely the EST design, excluding some aspects that are not relevant for automatic bootstrapping of constrained devices within a professional context. The parts supported by EST-coaps are:
+      <list style="hanging">
+        <t hangText="Message types:">
+          <list style="symbols">
+            <t>Simple enroll and reenroll.</t>
+            <t>CA certificate retrieval.</t> <!-- Needed when BRSKI is not applicable to establish the domain trust anchor -->
+            <t>CSR Attributes request messages.</t>
+            <t>Server-side key generation messages.</t>
+          </list></t>
+      </list> </t>
+    <t>The EST-coaps server URIs are identical to the EST URI (except for replacing the scheme https by coaps): </t>
 <figure align="left"><artwork><![CDATA[
 coaps://www.example.com/.well-known/est 
 coaps://www.example.com/.well-known/est/arbitraryLabel1
 ]]></artwork></figure>
-<t>
-See Figure 5 in section 3.2.2 of <xref target="RFC7030"/> for the path-suffixes (operations) that are supported by EST.
-</t><t>
-EST-coaps uses CoAP to transfer EST messages, aided by Block-Wise Transfer <xref target="RFC7959"/> to transport CoAP messages in blocks thus avoiding (excessive) 6LoWPAN fragmentation of UDP datagrams. The use of "Block" is specified in <xref target="fragment"/>.
-</t><t> The content-format (media type equivalent) of the CoAP message determines which EST message is transported in the CoAP payload. The media types specified in the HTTP Content-Type header(see section 3.2.2 of <xref target="RFC7030"/>) are in EST-coaps specified by the Content-Format Option (12) of CoAP. The combination of URI path-suffix and content-format used MUST map to an allowed combination of path-suffix and media type as defined for EST. 
+    <t>Figure 5 in section 3.2.2 of <xref target="RFC7030"/> addresses he path URIs (operations) are supported by EST. </t>
+    <t>The content-format (media type equivalent) of the CoAP message determines which EST message is transported in the CoAP payload. The media types specified in the HTTP Content-Type header(see section 3.2.2 of <xref target="RFC7030"/>) are in EST-coaps specified by the Content-Format Option (12) of CoAP. The combination of URI path-suffix and content-format used MUST map to an allowed combination of path-suffix and media type as defined for EST. The required content-formats for these request and response messages are defined in <xref target="iana"/>. The CoAP response codes are defined in <xref target="error"/>.</t> 
+    <t>EST-coaps is designed for use between low-resource devices using CoAP and hence does not need to send base64-encoded data. Simple binary coding is more efficient (30% less payload compared to base64) and well supported by CoAP. Therefore, the content formats specification in <xref target="iana"/> requires the use of binary encoding for all EST-coaps CoAP payloads. [EDNOTE: Revisit the binary format. ]</t>
 
-</t><t>EST-coaps is designed for use between low-resource devices using CoAP and hence does not need to send base64-encoded data. Simple binary coding is more efficient (30% less payload compared to base64) and well supported by CoAP. Therefore, the content formats specification in <xref target="iana"/> requires the use of binary encoding for all EST-coaps CoAP payloads.
-</t><t>
-The functions of TLS specified for EST are in EST-coaps mapped to the equivalent DTLS functions. However, DTLS sessions SHOULD remain open for persistent EST-coaps connections to reduce storage load. For example, a cacerts request followed by an enrollments request SHOULD use the same DTLS session.
-</t><t> The mandatory cipher suite for DTLS is TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 defined in <xref target="RFC7251"/> which is the mandatory-to-implement cipher suite in CoAP. Additionally the curve secp256r1 MUST be supported <xref target="RFC4492"/>; this curve is equivalent to the NIST P-256 curve. The hash algorithm is SHA-256. DTLS implementations MUST use the Supported Elliptic Curves and Supported Point Formats Extensions <xref target="RFC4492"/>; the uncompressed point format MUST be supported; <xref target="RFC6090"/> can be used as an implementation method.
-</t>
+    <section title="Message Bindings">
+      <t>This section describes BRSKI to CoAP message mappings.</t>
+      <t>CoAP defines confirmed (CON), acknowledgements (ACK), reset (RST) and non-corfirmed (NON) message types. For confirmable messages, the responses are CoAP ACKs or RSTs. All /cacerts, /simpleenroll, /simplereenroll, /csrattrs and /serverkeygen EST messages expect a response, so they are all COAP CON messages.</t>
+      <t>A CoAP message has the following fields (<xref target="RFC7252"></xref>):</t>
+      <t><figure>
+          <artwork><![CDATA[    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |Ver| T |  TKL  |      Code     |          Message ID           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Token (if any, TKL bytes) ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Options (if any) ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |1 1 1 1 1 1 1 1|    Payload (if any) ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
+        </figure></t>
+      <t>Then Ver, TKL, Token, Message ID are not affected in BRSKI. Their use is the same as in CoAP.</t>
 
-<section anchor="error" title="CoAP response codes">
-<t>
-Section 5.9 of <xref target="RFC7252"/> specifies the mapping of HTTP response codes to CoAP response codes. Every time the HTTP response code 200 is specified in <xref target="RFC7030"/> in response to a GET request, in EST-coaps the equivalent CoAP response code 2.05 MUST be used. Response code HTTP 202 in EST is mapped as indicated below; while other HTTP 2xx response codes are not used by EST. For the following HTTP 4xx error codes that may occur: 400, 401, 403, 404, 405, 406, 412, 413, 415 ; the equivalent CoAP response code for EST-coaps is 4.xx. For the HTTP 5xx error codes: 500, 501, 502, 503, 504 the equivalent CoAP response code is 5.xx. 
-</t><t>
-HTTP response code 202 needs a different treatment from the one described for <xref target="RFC7030"/>. A new CoAP response code 2.06 is needed. 
-When the EST over CoAP request cannot be treated immediately, a CoAP response code 2.06 Delayed is returned with Content-Format: application/link-format described in <xref target="RFC6690"/>. The payload of the response contains a link to receive the delayed response.
-ALTERNATIVE (to discuss) : a 2.06 Delayed response without payload and the link to receive the delayed response indicated using the Location-Path and Location-Query Options.
-</t><t> The waiting client may send GET requests to the returned link. When the response is not available, the server returns response code 2.06 with again the link for the client to query. When the response is available, the server returns the response code 2.05 Content with a payload containing the requested response in the appropriate content format.
-</t>
-</section> <!-- CoAP response codes -->
+      <t>The options that can be used in a CoAP header have the following format:</t>
 
-<section anchor="fragment" title="Message fragmentation using Block">
-<t>
-DTLS defines fragmentation only for the handshake part and not for secure data exchange (DTLS records).
-<xref target="RFC6347"/> states "Each DTLS record MUST fit within a single datagram".  In order to avoid using IP fragmentation, which is not supported by 6LoWPAN, invokers of the DTLS record layer MUST size DTLS records so that they fit within any Path MTU estimates obtained from the record layer. In addition, invokers residing on a 6LoWPAN over IEEE 802.15.4 network SHOULD attempt to size CoAP messages such that each DTLS record will fit within one or two IEEE 802.15.4 frames only by choosing the appropriate block sizes.
-</t><t>
-Certificates can vary greatly in size dependent on signature algorithms and key sizes. For a 256-bit curve, common ECDSA sizes fluctuate between 500 bytes and 1 KB. Some EST messages may be several kilobytes in size. Given non-existence of IP fragmentation in 6LoWPAN networks and its 1280 bytes MTU, EST-coaps needs to be able to fragment EST messages into multiple DTLS datagrams with each DTLS datagram containing a block of CoAP payload data. Further considering the small payload size available to a CoAP message, which can be as low as 68 bytes in case the message needs to fit into a single IEEE 802.15.4 frame, fine-grained fragmentation of EST messages is essential.
-</t><t>
-For CoAP, <xref target="RFC7959"/> specifies the "Block1" option for fragmentation of the request payload and the "Block2" option for fragmentation of the return payload. The CoAP client MAY specify the Block1 size and MAY also specify the Block2 size. The CoAP server MAY specify the Block2 size, but not the Block1 size.
-</t><t>
-Examples of fragmented messages are shown in <xref target="example"/>.
-</t>
-</section> <!-- Message fragmentation -->
+      <t><figure><artwork>
+       <![CDATA[     0   1   2   3   4   5   6   7
+   +---------------+---------------+
+   |  Option Delta | Option Length |   1 byte
+   +---------------+---------------+
+   /         Option Delta          /   0-2 bytes
+   \          (extended)           \
+   +-------------------------------+
+   /         Option Length         /   0-2 bytes
+   \          (extended)           \
+   +-------------------------------+
+   \                               \
+   /         Option Value          /   0 or more bytes
+   \                               \
+   +-------------------------------+]]>
+        </artwork></figure></t>
 
-<section anchor="messages" title="CoAP message headers">
-<t>
-EST-coaps uses CoAP payload blocks that each fit in a single DTLS record i.e. UDP datagram without causing IP fragmentation.
-The returned CoAP response codes are specified in <xref target="error"/>. The CoAP Token value is not specified by EST-coaps and may be chosen by the CoAP client according to <xref target="RFC7252"/>.
-</t><t>
-An example HTTP request message cacerts in EST will look like:
-</t>
-<figure align="left"><artwork><![CDATA[
-REQ:
-	GET /.well-known/est/cacerts HTTP/1.1
-	   Host: 192.0.2.1:8085
-	   Accept: */*
+      <t>Options are used to convey Uri-Host, Uri-Path, Uri-Port, Content-Format and more in COAP. For BRSKI, COAP Options are used to communicate the HTTP fields used in the BRSKI REST messages. </t>
 
-RES:
-	HTTP/1.1 200 OK
-	Status: 200 OK
-	Content-Type: application/pkcs7-mime
-	Content-Transfer-Encoding : base64
-	Content-Length: 4246
-	payload
-]]></artwork></figure>
-<t>
-The corresponding EST-coaps request looks like:
-</t>
-<figure align="left"><artwork><![CDATA[
-REQ:
-	GET coaps://[192.0.2.1:8085]/.well-known/est/cacerts
+      <t>BRSKI URLs are HTTPS based (https:// ), in CoAP these will be assumed to be transformed to coaps (coaps://)</t>
 
-RES:
-	2.05 Content (Content-Format: application/pkcs7-mime)
-	{payload}
-]]></artwork></figure>
+      <t>Some examples of how an BRSKI message would be translated in CoAP follow. [EDNOTE: This section to be expanded to ensure it covers all BRSKI edge conditions.] <xref target="messagebindings"/> includes some practical examples of EST messages translated to COAP. [EDNOTE: This section to be expanded. </t>
+    </section> <!-- Message bindings -->
 
-</section> <!-- CoAP message headers -->
+    <section anchor="error" title="CoAP response codes">
+      <t>Section 5.9 of <xref target="RFC7252"/> specifies the mapping of HTTP response codes to CoAP response codes. Every time the HTTP response code 200 is specified in <xref target="RFC7030"/> in response to a GET request, in EST-coaps the equivalent CoAP response code 2.05 MUST be used. Response code HTTP 202 in EST is mapped as indicated below; while other HTTP 2xx response codes are not used by EST. For the following HTTP 4xx error codes that may occur: 400, 401, 403, 404, 405, 406, 412, 413, 415 ; the equivalent CoAP response code for EST-coaps is 4.xx. For the HTTP 5xx error codes: 500, 501, 502, 503, 504 the equivalent CoAP response code is 5.xx.</t>
+      <t>HTTP response code 202 needs a different treatment from the one described for <xref target="RFC7030"/>. A new CoAP response code 2.06 is needed. When the EST over CoAP request cannot be treated immediately, a CoAP response code 2.06 Delayed is returned with Content-Format: application/link-format described in <xref target="RFC6690"/>. The payload of the response contains a link to receive the delayed response.
+ALTERNATIVE (to discuss) : a 2.06 Delayed response without payload and the link to receive the delayed response indicated using the Location-Path and Location-Query Options.</t>
+      <t>The waiting client may send GET requests to the returned link. When the response is not available, the server returns response code 2.06 with again the link for the client to query. When the response is available, the server returns the response code 2.05 Content with a payload containing the requested response in the appropriate content format.</t>
+      <t><xref target="messagebindings"/> includes some practical examples of HTTP response codes from EST translated to COAP.</t>
+    </section> <!-- CoAP response codes -->
 
-
+    <section anchor="fragment" title="Message fragmentation">
+      <t>DTLS defines fragmentation only for the handshake part and not for secure data exchange (DTLS records). <xref target="RFC6347"/> states "Each DTLS record MUST fit within a single datagram". In order to avoid using IP fragmentation, which is not supported by 6LoWPAN, invokers of the DTLS record layer MUST size DTLS records so that they fit within any Path MTU estimates obtained from the record layer. In addition, invokers residing on a 6LoWPAN over IEEE 802.15.4 network SHOULD attempt to size CoAP messages such that each DTLS record will fit within one or two IEEE 802.15.4 frames.</t>
+      <t>That is not always possible. Even though ECC certificates are small in size, they can vary greatly based on signature algorithms, key sizes, and OID fields used. For 256-bit curves, common ECDSA cert sizes are 500-1000 bytes which could fluctuate further based on the algorithms, OIDs, SANs and cert fields. For 384-bit curves, ECDSA certs increase in size and can sometimes reach 1.5KB. Additionally, there are times when the EST cacert response from the server can include multiple certs that amount large payloads. CoAP <xref target="RFC7252"/>'s section 4.6 describes the possible payload sizes: "if nothing is known about the size of the headers, good upper bounds are 1152 bytes for the message size and 1024 bytes for the payload size". Also "If IPv4 support on unusual networks is a consideration, implementations may want to limit themselves to more conservative IPv4 datagram sizes such as 576 bytes; per [RFC0791], the absolute minimum value of the IP MTU for IPv4 is as low as 68 bytes, which would leave only 40 bytes minus security overhead for a UDP payload". Thus, even with ECC certs, EST-coaps messages can still exceed sizes in MTU of 1280 for IPv6 or 60-80 bytes for 6LoWPAN <xref target="RFC4919"/> as explained in section 2 of <xref target="RFC7959"/>. EST-coaps needs to be able to fragment EST messages into multiple DTLS datagrams with each DTLS datagram. Fine-grained fragmentation of EST messages is essential.</t>
+      <t>To perform fragmentation in COAP, <xref target="RFC7959"/> specifies the "Block1" option for fragmentation of the request payload and the "Block2" option for fragmentation of the return payload of a COAP flow. Block1 options are used by the client PUT and POST requests. A Block1 in a client request requires a Block1 option in the responses. A Block2 comes from a server response that will also need Block2 from the client to acknowledge the block and get the rest of blocks from the server. Block1 is used when a request (POST for example) is used with a payload that needs fragmentation. The server responds with Block1 option to acknowledge the fragment-blocks. Block2 is used when a BRSKI server response is big and needs fragmentation. The Block2 acknowledgements are requests with the same options as the initial request and a Block2 option. "To influence the block size used in a response, the requester MAY also use the Block2 Option on the initial request, giving the desired size, a block number of zero and an M bit of zero". The CoAP client MAY specify the Block1 size and MAY also specify the Block2 size.  The CoAP server MAY specify the Block2 size, but not the Block1 size. As explained in Section 1 of <xref target="RFC7959"/>), blockwise transfers SHOULD be used in Confirmable COAP messages to avoid the exacerbation of lost blocks.</t>
+      <t>In a scenario with a big BRSKI POST request we might have Block1 options from client to server and Block2 from server to client. In this case the Block1 blocks get completed and then the Block2 flows the opposite direction.</t>
+      <t>The BLOCK draft also defines Size1 and Size2 options. These are used to convey the size of the resources in the requests or responses. The Size1 response MAY be parsed by the client as an size indication of the Block2 resource in the server response or by the server as a request for a size estimate by the client. Similarly, Size2 option defined in BLOCK should be parsed by the server as an indication of the size of the resource carried in Block1 options and by the client as a maximum size expected in the 4.13 (Request Entity Too Large) response to a request.</t>
+      <t>Block options in CoAP messages can contain fields, SZX, M and NUM which are not affected by BRSKI.</t>
+      <t>Examples of fragmented messages are shown in <xref target="blockexamples"/>.</t>
+    </section> <!-- Message fragmentation -->
 </section> <!-- protocol design and layering -->
 
-<section anchor="exchange" title = "Protocol Exchange Details">
-<t>
-The EST-coaps client MUST be configured with an implicit TA database or an explicit TA database.  The authentication of the EST-coaps server by the EST-coaps client is based on Certificate authentication in the DTLS handshake. 
-</t><t>
-The authentication of the EST-coaps client is based on client certificate in the DTLS handshake. This can either be
-<list style="symbols">
- <t>DTLS with a previously issued client certificate (e.g., an existing certificate issued by the EST CA); </t>
- <t>DTLS with a previously installed certificate (e.g., manufacturer-
-      installed certificate or a certificate issued by some other
-      party);</t>
-</list>
- 
-The details on checking the validity of the certificates are identical to EST.
-</t><t>
-The other protocol aspects such as simple enrollment (re-enrollment), certificate attributes and CA certificate request are similar to EST with the exception that these are performed on coaps (CoAP+DTLS) as the transport. The required content-formats for these request and response messages are defined in <xref target="iana"/>. The CoAP response codes are defined in <xref target="error"/>.
-</t><t>
-EST-coaps does not support full PKI Requests. Consequently, the fullcmc request of section 4.3 of <xref target="RFC7030"/> and response MUST NOT be supported by EST-coaps.
-</t>
-</section> <!-- Protocol exchange Details -->
 
-<section anchor="iana" title="IANA Considerations">
-<t>
-Additions to the sub-registry "CoAP
-Content-Formats", within the "CoRE Parameters" registry are needed for the below media types. These can be registered either in the Expert Review range (0-255) or IETF Review range (256-9999).
-<list style="numbers">
-<t>
-<list style ="symbols">
-   <t>application/pkcs7-mime</t>
-
-      <t>Type name: application</t>
-
-      <t>Subtype name: pkcs7-mime</t>
-
-      <t>smime-type: certs-only </t>
-
-      <t> ID: TBD1 </t>
-
-      <t>Required parameters: None</t>
-
-      <t>Optional parameters: None </t>
-
-      <t>Encoding considerations: Binary</t>
-
-      <t>Security considerations: As defined in this specification</t>
-
-      <t>Published specification: <xref target="RFC5751"/> </t>
-
-      <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
-</list>
-</t>
-<t>
-<list style ="symbols">
-   <t>application/pkcs8</t>
-
-      <t>Type name: application</t>
-
-      <t>Subtype name: pkcs8</t>
-
-      <t> ID: TBD2 </t>
-
-      <t>Required parameters: None</t>
-
-      <t>Optional parameters: None </t>
-
-      <t>Encoding considerations: Binary</t>
-
-      <t>Security considerations: As defined in this specification</t>
-
-      <t>Published specification: <xref target="RFC5958"/> </t>
-
-      <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
-</list>
-</t>
-<t>
-<list style ="symbols">
-   <t>application/csrattrs</t>
-
-      <t>Type name: application</t>
-
-      <t>Subtype name: csrattrs</t>
-
-      <t> ID: TBD3 </t>
-
-      <t>Required parameters: None</t>
-
-      <t>Optional parameters: None </t>
-
-      <t>Encoding considerations: Binary</t>
-
-      <t>Security considerations: As defined in this specification</t>
-
-      <t>Published specification: <xref target="RFC7030"/> </t>
-
-      <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
-</list>
-</t>
-
-<t>
-<list style ="symbols">
-   <t>application/pkcs10</t>
-
-      <t>Type name: application</t>
-
-      <t>Subtype name: pkcs10</t>
-
-      <t> ID: TBD4 </t>
-
-      <t>Required parameters: None</t>
-
-      <t>Optional parameters: None </t>
-
-      <t>Encoding considerations: binary</t>
-
-      <t>Security considerations: As defined in this specification</t>
-
-      <t>Published specification: <xref target="RFC5967"/> </t>
-
-      <t>Applications that use this media type: ANIMA bootstrap (BRSKI) and EST</t>
-</list>
-</t>
-</list>
-
-</t><t>
-Additions to the sub-registry "CoAP
-Response Code", within the "CoRE Parameters" registry are needed for the following response codes:
-<list style = "symbols">
-<t>Code: 2.06</t>
-<t>Description: Delayed </t>
-<t>Reference: this document</t>
-</list>
+  <section anchor="transport" title = "Transport Protocol">
+    <!-- [EDNOTE: This section mostly talked about DTLS. Panos renamed it to Transport Protocol that addresses DTLS and could be later updated to address COSE concerns etc. ] -->
+    <t>EST-coaps depends on a secure transport mechanism over UDP that can secure (confidentiality, authenticity) the COAP messages exchanged. </t>
+    
+    <section title = "DTLS">
+      <t> DTLS is one such secure protocol. Within BRSKI and EST when "TLS" is referred to, it is understood that in EST-coaps, security is provided using DTLS instead. No other changes are necessary (all provisional modes etc are the same as for TLS).</t>
+      <t>COAP was designed to avoid fragmentation. DTLS is used to secure COAP messages. When using DTLS, even though it can be avoided by using pre-shared keys or ECC ciphersuites, sometimes fragmentation will be needed. During the DTLS handshake, if fragmentation is necessary, "DTLS provides a mechanism for fragmenting a handshake message over a number of records, each of which can be transmitted separately, thus avoiding IP fragmentation" <xref target="RFC6347"/>.</t>
+      <t>The EST-coaps client MUST be configured with an explicit TA database at least an implicit TA database from its manufacturer. The authentication of the EST-coaps server by the EST-coaps client is based on Certificate authentication in the DTLS handshake.</t>
+      <t>The authentication of the EST-coaps client is based on client certificate in the DTLS handshake. This can either be
+        <list style="symbols">
+          <t>DTLS with a previously issued client certificate (e.g., an existing certificate issued by the EST CA); </t>
+          <t>DTLS with a previously installed certificate (e.g., manufacturer-installed certificate or a certificate issued by some other party);</t>
+        </list>
+        The details on checking the validity of the certificates are identical to EST.</t>
+      <t>EST-coaps does not support full PKI Requests. Consequently, the fullcmc request of section 4.3 of <xref target="RFC7030"/> and response MUST NOT be supported by EST-coaps.</t>
+      <t>Channel-binding information for linking proof-of-identity with message-based proof-of-possession (OPTIONAL). Given that CoAP and DTLS can provide proof of identity for EST-coaps clients and server, simple PKI messages can be used conformant to section 3.1 of <xref target="RFC5272"/>. EST-coaps supports the certificate types and Trust Anchors (TA) that are specified for EST in section 3 of <xref target="RFC7030"/>.
+      [EDNOTE: To describe POP in the DTLS context]</t>
+      <t>In a constrained CoAP environment, endpoints can't afford to establish a DTLS connection for every EST transaction. Authenticating and negotiating DTLS keys requires resources on low-end endpoints and consumes valuable bandwidth. The DTLS connection SHOULD remain open for persistent EST connections. For example, an EST cacerts request that is followed by a simpleenroll request can use the same authenticated DTLS connection. Given that after a successful enrollment, it is more likely that a new EST transaction will take place after a significant amount of time, the DTLS connections SHOULD only be kept alive for EST messages that are relatively close to each other.</t>
+      <t> The mandatory cipher suite for DTLS is TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 defined in <xref target="RFC7251"/> which is the mandatory-to-implement cipher suite in CoAP. Additionally the curve secp256r1 MUST be supported <xref target="RFC4492"/>; this curve is equivalent to the NIST P-256 curve. The hash algorithm is SHA-256. DTLS implementations MUST use the Supported Elliptic Curves and Supported Point Formats Extensions <xref target="RFC4492"/>; the uncompressed point format MUST be supported; <xref target="RFC6090"/> can be used as an implementation method.</t>
+    </section>
+    <section title = "[EDNOTE: Placeholder]">
+      <t>[EDNOTE: Other secure transport mechanisms placeholder section. ]</t>
+    </section>
+  </section> <!-- Transport Protocol -->
 
 
-</t>
-</section>  <!-- IANA consideration -->
+  <section title="Proxying">
+    <t>[EDNOTE: This section to be populated. It will address how proxying can take place by an entity that resides at the edge of the CoAP network, such as the Registrar, and can reach the BRSKI server residing in a traditional "TCP setting". ]</t>
+  </section>
 
-<section anchor="sec" title="Security Considerations">
-<t>The security considerations mentioned in EST applies also to EST-coaps.  
-</t>
-</section>  <!-- Security considerations  -->
+  <section title="Parameters">
+    <t>[EDNOTE: This section to be populated. It will address transmission parameters for BRSKI described in sections 4.7 and 4.8 of the CoAP draft. BRSKI does not impose any unique parameters that affect the CoAP parameters in Table 2 and 3 in the CoAP draft but the ones in CoAP could be affecting BRSKI. For example the processing delay of CAs could be less then 2s, but in this case they should send an CoAP ACK every 2s while processing.]</t>
+  </section>
 
-<section anchor="ack" title="Acknowledgements">
-<t> The authors are very grateful to Klaus Hartke for his detailed explanations on the use of Block with DTLS. The authors would like to thank Esko Dijk and Michael Verschoor for the valuable discussions that helped in shaping the solution.
-</t>
-</section> <!-- Acknowledgements  -->
+  <section anchor="iana" title="IANA Considerations">
+    <t>Additions to the sub-registry "CoAPContent-Formats", within the "CoRE Parameters" registry are needed for the below media types. These can be registered either in the Expert Review range (0-255) or IETF Review range (256-9999).
+    <list style="numbers">
+      <t><list style ="symbols">
+           <t>application/pkcs7-mime</t>
+           <t>Type name: application</t>
+           <t>Subtype name: pkcs7-mime</t>
+           <t>smime-type: certs-only </t>
+           <t> ID: TBD1 </t>
+           <t>Required parameters: None</t>
+           <t>Optional parameters: None </t>
+           <t>Encoding considerations: Binary</t>
+           <t>Security considerations: As defined in this specification</t>
+           <t>Published specification: <xref target="RFC5751"/> </t>
+           <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
+         </list></t>
+      <t><list style ="symbols">
+           <t>application/pkcs8</t>
+           <t>Type name: application</t>
+           <t>Subtype name: pkcs8</t>
+           <t>ID: TBD2 </t>
+           <t>Required parameters: None</t>
+           <t>Optional parameters: None </t>
+           <t>Encoding considerations: Binary</t>
+           <t>Security considerations: As defined in this specification</t>
+           <t>Published specification: <xref target="RFC5958"/> </t>
+           <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
+        </list></t>
+      <t><list style ="symbols">
+           <t>application/csrattrs</t>
+           <t>Type name: application</t>
+           <t>Subtype name: csrattrs</t>
+           <t> ID: TBD3 </t>
+           <t>Required parameters: None</t>
+           <t>Optional parameters: None </t>
+           <t>Encoding considerations: Binary</t>
+           <t>Security considerations: As defined in this specification</t>
+           <t>Published specification: <xref target="RFC7030"/> </t>
+           <t>Applications that use this media type: ANIMA Bootstrap (BRSKI) and EST</t>
+         </list></t>
+      <t><list style ="symbols">
+           <t>application/pkcs10</t>
+           <t>Type name: application</t>
+           <t>Subtype name: pkcs10</t>
+           <t> ID: TBD4 </t>
+           <t>Required paraeters: None</t>
+           <t>Optional parameters: None </t>
+           <t>Encoding considerations: binary</t>
+           <t>Security considerations: As defined in this specification</t>
+           <t>Published specification: <xref target="RFC5967"/> </t>
+           <t>Applications that use this media type: ANIMA bootstrap (BRSKI) and EST</t>
+         </list></t>
+    </list></t>
+    <t>Additions to the sub-registry "CoAP Response Code", within the "CoRE Parameters" registry are needed for the following response codes:
+    <list style = "symbols">
+      <t>Code: 2.06</t>
+      <t>Description: Delayed </t>
+      <t>Reference: this document</t>
+    </list></t>
+    <t>[EDNOTE: This section will be expanded to includes types needed that do not exist in COAP.] </t>
+  </section>  <!-- IANA consideration -->
 
-<section anchor="changes" title="Change Log">
-<t>
-</t>
-</section>
+  <section anchor="sec" title="Security Considerations">
+    <t>[EDNOTE: This section to be populated. This document describes an existing protocol moved to CoAP and there should not be additional security concerns added beyond the protocol's or CoAP's specifics security considerations. The security considerations mentioned in EST applies also to EST-coaps. Specifically for server-side key generation, it introduces implications for the endpoints and their private keys, which will be covered here. ]</t>
+  </section>  <!-- Security considerations  -->
 
+  <section anchor="ack" title="Acknowledgements">
+    <t>The authors are very grateful to Klaus Hartke for his detailed explanations on the use of Block with DTLS. The authors would like to thank Esko Dijk and Michael Verschoor for the valuable discussions that helped in shaping the solution. They would also like to thank Peter Panburana from Cisco for his feedback on technical details of the solution.</t>
+  </section> <!-- Acknowledgements  -->
+
+  <section anchor="changes" title="Change Log">
+    <t> -01:
+         <list style="empty">
+           <t>Merging of draft-vanderstok-ace-coap-est-00 and draft-vanderstok-ace-coap-est-01</t>
+         </list>
+    </t>
+  </section> <!-- Change Log -->
 </middle>
 
 
 <back>
-    <references title="Normative References">
-     &RFC2119;
-     &RFC4492;
-     &RFC5272;
-     &RFC5751;
-     &RFC5958;
-	&RFC5967;
-     &RFC6090;
-     &RFC6347;
-     &RFC6690;   
-     &RFC7030;
-     &RFC7251;
-     &RFC7252;
-     &RFC7959;
-     &I-D.ietf-anima-bootstrapping-keyinfra;
+  <references title="Normative References">
+    &RFC2119;
+    &RFC5272;
+    &RFC5751;
+    &RFC5967;
+    &RFC6347;
+    &RFC6690;   
+    &RFC7030;
+    &RFC7252;
+    &RFC7959;
+    &I-D.ietf-anima-bootstrapping-keyinfra;
+  </references>
+  <references title="Informative References">
+    &RFC4492;
+    &RFC4944;
+    &RFC5246;
+    &RFC5958;
+    &RFC6090;
+    <!-- &RFC6838; -->
+    &RFC7230;
+    &RFC7251;
+    &RFC7641;
+    &RFC4919;
+    <reference anchor="ieee802.15.4">
+      <front>
+        <title>IEEE Standard 802.15.4-2006</title>
+        <author surname="Institute of Electrical and Electronics Engineers">
+        </author>
+        <date month="" year="2006" />
+      </front>
+    </reference>
+  </references>
 
-   
-    </references>
-    <references title="Informative References">
-      &RFC4944;
-      &RFC5246;
-      &RFC6838;
-      &RFC7230;
-	
+  <section anchor="messagebindings" title="EST messages to EST-coaps">
+    <section title="cacerts">
+      <t>In EST, an HTTPS cacerts message can be</t>
+      <figure>
+        <artwork><![CDATA[  GET /.well-known/est/cacerts HTTP/1.1
+     User-Agent: curl/7.22.0 (i686-pc-linux-gnu) libcurl/7.22.0 
+                 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
+     Host: 192.0.2.1:8085
+     Accept: */*]]></artwork>
+      </figure>
 
-<reference anchor="ieee802.15.4">
-        <front>
-          <title>IEEE Standard 802.15.4-2006</title>
-
-          <author surname="Institute of Electrical and Electronics Engineers">
-            <organization></organization>
-          </author>
-
-          <date month="" year="2006" />
-        </front>
-      </reference>
-
-
-    </references>
-
-<section anchor="example" title="Operational Scenario Example Messages">
-<t>
-This appendix provides detailed examples of the messages using DTLS and BLOCK option Block2. The minimum PMTU is 1280 bytes, which is the example value assumed for the DTLS datagram size. The example block length is taken as 64 which gives an SZX value of 2.
-</t><t>
-The following is an example of a valid /cacerts exchange.
-</t><t>
-During the initial DTLS handshake, the client can ignore the optional server-generated "certificate request" and can instead proceed with the CoAP GET request. The content length of the cacerts response in appendix A.1 of <xref target="RFC7030"/> is 4246 bytes using base64. This leads to a length of 3185 bytes in binary. The CoAP message adds around 10 bytes, the DTLS record 29 bytes. 
-</t><t>To avoid IP fragmentation, the CoAP block option is used and an MTU of 127 is assumed to stay within one IEEE 802.15.4 packet. To stay below the MTU of 127, the payload is split in 50 packets with a payload of 64 bytes each. Fifty times the client sends an IPv6 packet containing the UDP datagram with the DTLS record that encapsulates the CoAP Request. The server returns an IPv6 packet containing the UDP datagram with the DTLS record that encapsulates the CoAP response.
-</t><t> The CoAP request-response exchange with block option is shown below. Block option is shown in a decomposed way indicating the kind of Block option (2 in this case because used in the response) followed by a colon, and then the block number (NUM), the more bit (M = 0 means last block), and block size exponent (2**(SZX+4)) separated by slashes. The Length 64 is used with SZX= 2 to avoid IP fragmentation.
-</t><t> The CoAP Request is sent with confirmable (CON) option and the content format of the Response is /application/cacerts.
-</t>
+      <t>The corresponding CoAP request is </t>
 <figure align="left"><artwork><![CDATA[
+REQ:
+	GET coaps://[192.0.2.1:8085]/.well-known/est/cacerts
+]]></artwork></figure>
+      <t>with COAP fields</t>
+      <figure><artwork>
+<![CDATA[  Ver = 1
+  T = 0 (CON)
+  Code = 0x01 (0.01 is GET)
+  Options
+   Option1 (Uri-Host)
+     Option Delta = 0x3
+     Option Length = 0x9
+     Option Value = 192.0.2.1
+   Option2 (Uri-Port)
+     Option Delta = 0xA
+     Option Length = 0x4
+     Option Value = 8085
+   Option3 (Uri-Path)
+     Option Delta = 0xD
+     Option Length = 0xD
+     Extended Option Delta = 0x08
+     Extended Option Length = 0x14
+     Option Value = /.well-known/est/cacerts HTTP/1.1
+  Payload = [Empty]
+]]></artwork></figure>
 
+      <t>A 200 OK response with a cert in EST will them be</t>
+      <figure><artwork>
+<![CDATA[   HTTP/1.1 200 OK
+   Status: 200 OK
+   Content-Type: application/pkcs7-mime
+   Content-Transfer-Encoding: base64 [EDNOTE: Verify if we need a new 
+                                      option registry for Encoding?)
+   Content-Length: 4246 [EDNOTE: this example overflows and would
+                         need fragmentation. Choose a better example.
+                         Regardless we might need an CoAP option for
+                         the content-length ie the CoAP payload?)
+
+   MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExADALBgkqhkiG9w0BBwGgggwMMIIC
+   +zCCAeOgAwIBAgIJAJpY3nUZO3qcMA0GCSqGSIb3DQEBBQUAMBsxGTAXBgNVBAMT
+   ...]]></artwork></figure>
+
+        <t>The corresponding CoAP response is </t>
+          <figure align="left"><artwork><![CDATA[
+RES:
+	2.05 Content (Content-Format: application/pkcs7-mime)
+	{payload}
+]]></artwork></figure>
+        <t>with COAP fields </t>
+          <figure><artwork>
+<![CDATA[  Ver = 1
+  T = 2 (ACK)
+  Code = 0x21 [EDNOTE: Maybe we need to create a 0x200 response code.) 
+  Options
+    Option1 (Content-Format)
+      Option Delta = 0xC
+      Option Length = 0xD
+      Extended Option Length = 0x09
+      Option Value = <number for application/pkcs7-mime> 
+                [EDNOTE: We need a new CoAP IANA registered value   
+                application/pkcs7-mime; smime-type=certs-only, 
+                application/csrattrs, application/pkcs10, 
+                application/pkcs8, 
+                application/pkcs12 )
+  Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYCAQExA \
+              DALBgkqhkiG9w0BBwGgggwMMIIC...]]></artwork></figure>
+    </section>  <!-- cacerts -->
+
+    <section title="enroll / reenroll">
+      <t>[EDNOTE: username/password authentication can be described here but is
+        not a primary focus for BRSKI. It is important for generic EST exchanges
+        but would an endpoint device with sufficient user interface to allow
+        username/password input from an end user be required to use CoAP instead
+        of a full HTTPS exchange?]</t>
+
+      <t>[EDNOTE: We might need a new Option for the Retry-After response
+        message. We might need a new Option for the WWW-Authenticate
+        response.]</t>
+
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+    </section>  <!-- enroll / reenroll -->
+
+    <section title="csrattr">
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+    </section>  <!-- csrattr -->
+
+    <section title="enrollstatus">
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+    </section>  <!-- enrollstatus -->
+
+    <section title="voucher_status">
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+    </section>  <!-- voucher_status -->
+
+    <section title="requestvoucher">
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+    </section>  <!-- requestvoucher -->
+
+    <section title="requestlog">
+      <t>[EDNOTE: Include COAP message examples. ]</t>
+      <t>[EDNOTE: More examples can be added, for server-side key generation in CMS envelopes. ]</t>
+    </section>  <!-- requestlog -->
+  </section>  <!-- EST messages to EST-coaps -->
+
+  <section anchor="blockexamples" title="EST-coaps Block message examples">
+    <t>This section provides detailed examples of the messages using DTLS and BLOCK option Block2. The minimum PMTU is 1280 bytes, which is the example value assumed for the DTLS datagram size. The example block length is taken as 64 which gives an SZX value of 2.</t>
+    <t>The following is an example of a valid /cacerts exchange over DTLS. <!-- During the initial DTLS handshake, the client can ignore the optional server-generated "certificate request" and can instead proceed with the CoAP GET request -->. The content length of the cacerts response in appendix A.1 of <xref target="RFC7030"/> is 4246 bytes using base64. This leads to a length of 3185 bytes in binary. The CoAP message adds around 10 bytes, the DTLS record 29 bytes. To avoid IP fragmentation, the CoAP block option is used and an MTU of 127 is assumed to stay within one IEEE 802.15.4 packet. To stay below the MTU of 127, the payload is split in 50 packets with a payload of 64 bytes each. The client sends an IPv6 packet containing the UDP datagram with the DTLS record that encapsulates the CoAP Request 50 times. The server returns an IPv6 packet containing the UDP datagram with the DTLS record that encapsulates the CoAP response. The CoAP request-response exchange with block option is shown below. Block option is shown in a decomposed way indicating the kind of Block option (2 in this case because used in the response) followed by a colon, and then the block number (NUM), the more bit (M = 0 means last block), and block size exponent (2**(SZX+4)) separated by slashes. The Length 64 is used with SZX= 2 to avoid IP fragmentation. The CoAP Request is sent with confirmable (CON) option and the content format of the Response is /application/cacerts.</t>
+    <figure align="left"><artwork><![CDATA[
 GET [192.0.2.1:8085]/.well-known/est/cacerts     -->
               <--   (2:0/1/64) 2.05 Content
     GET URI (2:1/1/64)                           -->
@@ -484,11 +486,114 @@ GET [192.0.2.1:8085]/.well-known/est/cacerts     -->
                       |
      GET URI (2:49/1/64)                         -->
               <--   (2:49/0/64) 2.05 Content
-
 ]]></artwork></figure>
 
-</section> <!-- Operational scenario example messages -->
+    <t>An example HTTP cacerts response that exceeds the MTU can be 
+      <figure><artwork>
+<![CDATA[HTTP/1.1 200 OK
+   Status: 200 OK
+   Content-Type: application/pkcs7-mime; smime-type=certs-only
+   Content-Transfer-Encoding: base64
+   Content-Length: 1122
 
+   MIIDOAYJKoZIhvcNAQcCoIIDKTCCAyUCAQExADALBgkqhkiG9w0BBwGgggMLMIID
+   BzCCAe+gAwIBAgIBFTANBgkqhkiG9w0BAQUFADAbMRkwFwYDVQQDExBlc3RFeGFt
+   cGxlQ0EgTndOMB4XDTEzMDUwOTIzMTU1M1oXDTE0MDUwOTIzMTU1M1owHzEdMBsG
+   A1UEAxMUZGVtb3N0ZXA0IDEzNjgxNDEzNTIwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+   DwAwggEKAoIBAQClNp+kdz+Nj8XpEp9kaumWxDZ3eFYJpQKz9ddD5e5OzUeCm103
+   ZIXQIxc0eVtMCatnRr3dnZRCAxGjwbqoB3eKt29/XSQffVv+odbyw0WdkQOIbntC
+   Qry8YdcBZ+8LjI/N7M2krmjmoSLmLwU2V4aNKf0YMLR5Krmah3Ik31jmYCSvwTnv
+   6mx6pr2pTJ82JavhTEIIt/fAYq1RYhkM1CXoBL+yhEoDanN7TzC94skfS3VV+f53
+   J9SkUxTYcy1Rw0k3VXfxWwy+cSKEPREl7I6k0YeKtDEVAgBIEYM/L1S69RXTLuji
+   rwnqSRjOquzkAkD31BE961KZCxeYGrhxaR4PAgMBAAGjUjBQMA4GA1UdDwEB/wQE
+   AwIEsDAdBgNVHQ4EFgQU/qDdB6ii6icQ8wGMXvy1jfE4xtUwHwYDVR0jBBgwFoAU
+   scRp5lujBKfYl6OLO7+5arIyQjwwDQYJKoZIhvcNAQEFBQADggEBACmxg1hvL6+7
+   a+lFTARoxainBx5gxdZ9omSb0L+qL+4PDvg/+KHzKsDnMCrcU6M4YP5n0EDKmGa6
+   4lY8fbET4tt7juJg6ixb95/760Th0vuctwkGr6+D6ETTfqyHnrbhX3lAhnB+0Ja7
+   o1gv4CWxh1I8aRaTXdpOHORvN0SMXdcrlCys2vrtOl+LjR2a3kajJO6eQ5leOdzF
+   QlZfOPhaLWen0e2BLNJI0vsC2Fa+2LMCnfC38XfGALa5A8e7fNHXWZBjXZLBCza3
+   rEs9Mlh2CjA/ocSC/WxmMvd+Eqnt/FpggRy+F8IZSRvBaRUCtGE1lgDmu6AFUxce
+   R4POrT2xz8ChADEA
+   ]]></artwork></figure></t>
+
+    <t>As another example, let's assume that the cacerts message will need to be broken up to three messages. The first Block2 will be 
+    <figure><artwork>
+<![CDATA[  Ver = 1
+  T = 2 (ACK)
+  Code = 0x21 (2.01 success message. 
+         EDNOTE: Do we need to create a 0x200 respond code.) 
+  Options
+    Option1 (Content-Format)
+      Option Delta = 0xC
+      Option Length = 0xD
+      Extended Option Length = 0x09
+      Option Value = <number for application/pkcs7-mime; 
+                      smime-type=certs-only> 
+                [EDNOTE: We need a new CoAP IANA registered value 
+                application/pkcs7-mime, application/csrattrs, 
+                application/pkcs10, application/pkcs8, 
+                application/pkcs12]
+    Option2 (Block2)
+      Option Delta = 0xD
+      Option Length = 0x1
+      Extended Option Delta = 0x16
+      Option Value = 0x0D
+  Payload = MIIMOQYJKoZIhvcNAQcCoIIMKjCCDCYC \
+            AQExADALBgkqhkiG9w0BBwGgggwMMIIC... (512 bytes)
+[EDNOTE: Potentially replace base64 with binary ]
+]]></artwork>
+          </figure></t>
+
+    <t>The second Block2:
+    <figure><artwork>
+<![CDATA[  Ver = 1
+  T = 2 (means ACK)
+  Code = 0x21
+  Options
+    Option1 (Content-Format)
+      Option Delta = 0xC
+      Option Length = 0xD
+      Extended Option Length = 0x09
+      Option Value = <number for application/pkcs7-mime; 
+                     smime-type=certs-only> 
+                [EDNOTE: We need a new CoAP IANA registered value  
+                application/pkcs7-mime, application/csrattrs, 
+                application/pkcs10, application/pkcs8, 
+                application/pkcs12 ]
+    Option2 (Block2)
+      Option Delta = 0xD
+      Option Length = 0x1
+      Extended Option Delta = 0x16
+      Option Value = 0x1D
+  Payload = ... (512 bytes)]]></artwork></figure></t>
+
+    <t>The third and final Block2:
+    <figure><artwork>
+<![CDATA[  Ver = 1
+  T = 2 (means ACK)
+  Code = 0x21
+  Options
+    Option1 (Content-Format)
+      Option Delta = 0xC
+      Option Length = 0xD
+      Extended Option Length = 0x09
+      Option Value = <number for application/pkcs7-mime; 
+                      smime-type=certs-only> 
+                [EDNOTE: We need a new CoAP IANA registered value 
+                application/pkcs7-mime, application/csrattrs, 
+                application/pkcs10, application/pkcs8, 
+                application/pkcs12 ]
+    Option2 (Block2)
+      Option Delta = 0xD
+      Option Length = 0x1
+      Extended Option Delta = 0x16
+      Option Value = 0x25
+  Payload = ... ]]></artwork></figure></t>
+
+      <t>[EDNOTE: We can add Fragmented request example with Block1 ] </t>
+
+      <t>[EDNOTE: Fragmented request/response example with Block1, Size1 and Block2"> </t>
+  </section> <!-- EST-coaps Block message examples -->
 </back>
 
 </rfc>


### PR DESCRIPTION
This pull request merges https://tools.ietf.org/html/draft-pritikin-coap-bootstrap https://www.ietf.org/id/draft-vanderstok-ace-coap-est. It contains a series of changes: 
- Created two appendix sections.
- The EST-coaps examples and the block example were moved to the appendix.
- I made a secure transport section that covers DTLS. Theoretically it could later incorporate other secure transport mechanisms like OSCOAP. 
- Added a section about proxying and connection parameters. 
- Rearranged text to avoid repetitions.
- Reformatted to a more xml readable format.
- Made all kinds of text changes.
Panos

